### PR TITLE
fix: 待办公务有可做任务但显示“当前没有可办公务”后结束任务

### DIFF
--- a/assets/resource/base/pipeline/bird_food_4.json
+++ b/assets/resource/base/pipeline/bird_food_4.json
@@ -130,7 +130,9 @@
   "识别下一份鸢报": {
     "recognition": "OCR",
     "expected": "鸢报抵达",
-    "next": ["等待鸢报抵达"]
+    "next": ["等待鸢报抵达"],
+    "on_error": ["待办公务可做任务"],
+    "timeout": 5000
   },
   "等待鸢报抵达": {
     "pre_delay": 15000,


### PR DESCRIPTION
不确定是不是这个原因……也许是识别下一份鸢报"鸢报抵达"的时候任务刚好刷新出来了，导致识别超时结束任务。可能性很小但不是0（？）