### PR TITLE
fix: 寒夜厄境bug

### DIFF
--- a/agent/custom/action/energycheck.py
+++ b/agent/custom/action/energycheck.py
@@ -62,7 +62,9 @@ class EnergyCheck(CustomAction):
         elif energy_value < 10:
             # 体力小于10，改写"寒夜厄境-确定结算"的next为stop
             context.override_next("寒夜厄境-获得雪山秘宝", ["寒夜厄境-切换到资源牌"])
-            context.override_next("寒夜厄境-确定结算", ["stop"])
+            context.override_next("寒夜厄境-体力check", ["寒夜厄境-洞察牌check", "寒夜厄境-切换到资源牌"])
+            context.override_next("寒夜厄境-确定结算", ["寒夜厄境-结束后体力check"])
+            context.override_next("寒夜厄境-结束后体力check", ["stop"])
             logger.info("检测到体力小于10，尝试开启所有雪山秘宝并结束任务")
         
         return CustomAction.RunResult(success=True)

--- a/assets/resource/base/pipeline/sp/han_ye_e_jing.json
+++ b/assets/resource/base/pipeline/sp/han_ye_e_jing.json
@@ -230,7 +230,7 @@
       }
     },
     "next": ["寒夜厄境-洞察牌check", "寒夜厄境-点击退出章节"],
-    "post_delay": 2000,
+    "post_delay": 500,
     "timeout": 4000
   },
   "寒夜厄境-切换到资源牌": {
@@ -330,5 +330,20 @@
     "post_delay": 1000,
     "timeout": 4000,
     "next": ["寒夜厄境-点击继续故事"]
+  },
+  "寒夜厄境-结束后体力check": {
+    "recognition": {
+      "type": "DirectHit",
+      "param": {}
+    },
+    "action": {
+      "type": "Custom",
+      "param": {
+        "custom_action": "EnergyCheck"
+      }
+    },
+    "next": ["寒夜厄境-点击继续故事"],
+    "post_delay": 2000,
+    "timeout": 4000
   }
 }

--- a/assets/resource/zh_tw/pipeline/sp/han_ye_e_jing.json
+++ b/assets/resource/zh_tw/pipeline/sp/han_ye_e_jing.json
@@ -230,7 +230,7 @@
       }
     },
     "next": ["寒夜厄境-洞察牌check", "寒夜厄境-点击退出章节"],
-    "post_delay": 2000,
+    "post_delay": 500,
     "timeout": 4000
   },
   "寒夜厄境-切换到资源牌": {
@@ -330,5 +330,20 @@
     "post_delay": 1000,
     "timeout": 4000,
     "next": ["寒夜厄境-点击继续故事"]
+  },
+  "寒夜厄境-结束后体力check": {
+    "recognition": {
+      "type": "DirectHit",
+      "param": {}
+    },
+    "action": {
+      "type": "Custom",
+      "param": {
+        "custom_action": "EnergyCheck"
+      }
+    },
+    "next": ["寒夜厄境-点击继续故事"],
+    "post_delay": 2000,
+    "timeout": 4000
   }
 }


### PR DESCRIPTION
1.修复体力＜10时没有洞察牌的话没开秘宝就直接退出了
2.退出后再次check体力，以防秘宝开出过多体力
不过都最后一天了还有修的必要吗（）