### PR TITLE
feat: add star capture to toolbox

### DIFF
--- a/agent/custom/action/__init__.py
+++ b/agent/custom/action/__init__.py
@@ -16,6 +16,8 @@ from .bbq_v3_custom import *
 from .cvpls import *
 from .cvpls_config import *
 from .paged_item_recognition import *
+from .star_backpack_capture_probe import *
+from .star_backpack_capture_orchestration import *
 from .fixed_reward_reporting import *
 from .experience_book_stock_reporting import *
 from .bird_food import *
@@ -47,6 +49,8 @@ __all__ = [
     "CVPLSScreen",
     "CVPLSConfigure",
     "PagedItemRecognition",
+    "StarBackpackCaptureProbe",
+    "StarBackpackCaptureOrchestration",
     "FixedRewardReporting",
     "ExperienceBookStockReporting",
     "BirdFood1TaskScan",

--- a/agent/custom/action/star_backpack_capture_orchestration.py
+++ b/agent/custom/action/star_backpack_capture_orchestration.py
@@ -1,0 +1,192 @@
+"""Production three-section star-backpack capture orchestration.
+
+This module deliberately owns only sequence, tab switching, and CaptureBatch
+assembly.  Pixel motion and semantic-overlap decisions remain in the already
+verified ``StarBackpackCaptureProbe`` continuous-capture primitive.
+"""
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from maa.agent.agent_server import AgentServer
+from maa.context import Context
+from maa.custom_action import CustomAction
+
+from custom.action.star_backpack_capture_probe import (
+    StarBackpackCaptureProbe,
+    _parse_int,
+    _parse_params,
+    _prepare_run_directory,
+    _write_json,
+    _write_png,
+    parse_capture_probe_params,
+)
+from custom.action.star_capture_transport import upload_full_capture_batch
+from utils import logger
+
+
+def parse_star_backpack_capture_orchestration_params(raw: Any) -> dict[str, Any]:
+    """Parse the B5 production entry without enabling B4 transport."""
+    raw_params = _parse_params(raw)
+    if raw_params.get("mode") != "continuous_capture":
+        raise ValueError("正式星石背包采集必须使用 continuous_capture")
+    parsed = parse_capture_probe_params(raw_params)
+    for field in ("support_tab_task", "experience_tab_task"):
+        value = raw_params.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{field} 必须是非空 pipeline 节点名")
+        parsed[field] = value.strip()
+    parsed["tab_settle_ms"] = _parse_int(
+        raw_params.get("tab_settle_ms"), "tab_settle_ms", minimum=0
+    )
+    return parsed
+
+
+def _task_succeeded(detail: Any) -> bool:
+    if isinstance(detail, bool):
+        return detail
+    status = getattr(detail, "status", None)
+    return bool(status and getattr(status, "succeeded", False))
+
+
+def _switch_tab(context: Context, task_name: str, settle_ms: int) -> None:
+    if not _task_succeeded(context.run_task(task_name)):
+        raise RuntimeError(f"星石背包切换 Tab 失败: {task_name}")
+    if settle_ms:
+        time.sleep(settle_ms / 1000)
+
+
+def _section_payload(
+    section: str,
+    session: dict[str, Any],
+    capture_id: str,
+    source_order: int,
+) -> tuple[dict[str, Any], int]:
+    image_names = session["retained_images"]
+    source_id_by_name = {
+        image_name: f"{capture_id}:{section}:{index:03d}"
+        for index, image_name in enumerate(image_names)
+    }
+    images = []
+    for index, image_name in enumerate(image_names):
+        images.append(
+            {
+                "sourceImageId": source_id_by_name[image_name],
+                "sourceOrder": source_order + index,
+                # MaaYuan retains PNGs locally.  The later transport/import
+                # boundary supplies File objects and is intentionally out of B5.
+                "fileName": f"{section}/{image_name}",
+            }
+        )
+    relations = [
+        {
+            "previousSourceImageId": source_id_by_name[relation["previous_image"]],
+            "currentSourceImageId": source_id_by_name[relation["current_image"]],
+            "relation": "overlap",
+        }
+        for relation in session["adjacent_relations"]
+    ]
+    return (
+        {
+            "images": images,
+            "adjacentRelations": relations,
+            "complete": True,
+            "stopReason": "single_capture" if section == "experience" else "bottom_no_move",
+        },
+        source_order + len(images),
+    )
+
+
+def assemble_capture_batch(
+    run_dir: Path,
+    game_version: str,
+    main: dict[str, Any],
+    support: dict[str, Any],
+    experience: dict[str, Any],
+) -> dict[str, Any]:
+    """Assemble the local, file-name based representation of CaptureBatchV1."""
+    if not main["success"] or not support["success"]:
+        raise ValueError("未完成的主星或辅星采集不能组装完整 CaptureBatchV1")
+    capture_id = "star-" + uuid.uuid5(uuid.NAMESPACE_URL, run_dir.resolve().as_uri()).hex
+    next_order = 1
+    sections: dict[str, dict[str, Any]] = {}
+    for section, session in (("main", main), ("support", support), ("experience", experience)):
+        sections[section], next_order = _section_payload(
+            section, session, capture_id, next_order
+        )
+    return {
+        "schemaVersion": 1,
+        "captureId": capture_id,
+        "source": "maayuan",
+        "gameVersion": game_version,
+        "sections": sections,
+    }
+
+
+@AgentServer.custom_action("StarBackpackCaptureOrchestration")
+class StarBackpackCaptureOrchestration(CustomAction):
+    """Run main → support → experience capture with no OCR or transport."""
+
+    def run(
+        self, context: Context, argv: CustomAction.RunArg
+    ) -> CustomAction.RunResult:
+        try:
+            params = parse_star_backpack_capture_orchestration_params(
+                argv.custom_action_param
+            )
+            run_dir = _prepare_run_directory(params["debug_dir"])
+            probe = StarBackpackCaptureProbe()
+
+            (run_dir / "main").mkdir(parents=True, exist_ok=False)
+            main = probe._run_continuous_capture(
+                context, params, run_dir / "main", probe._capture(context)
+            )
+            if not main["success"]:
+                logger.warning("星石背包主星未完整采集，停止后续 Tab 切换。")
+                return CustomAction.RunResult(success=False)
+
+            _switch_tab(context, params["support_tab_task"], params["tab_settle_ms"])
+            (run_dir / "support").mkdir(parents=True, exist_ok=False)
+            support = probe._run_continuous_capture(
+                context, params, run_dir / "support", probe._capture(context)
+            )
+            if not support["success"]:
+                logger.warning("星石背包辅星未完整采集，停止经验星曜截图。")
+                return CustomAction.RunResult(success=False)
+
+            _switch_tab(context, params["experience_tab_task"], params["tab_settle_ms"])
+            experience_dir = run_dir / "experience"
+            experience_dir.mkdir(parents=True, exist_ok=False)
+            experience_image = probe._capture(context)
+            experience_name = "capture-00.png"
+            _write_png(experience_dir / experience_name, experience_image)
+            experience = {
+                "success": True,
+                "stop_reason": "single_capture",
+                "retained_images": [experience_name],
+                "retained_image_count": 1,
+                "adjacent_relations": [],
+                "transition_count": 0,
+                "failed_transition": None,
+            }
+            _write_json(experience_dir / "session.json", experience)
+
+            batch = assemble_capture_batch(
+                run_dir, params["game_version"], main, support, experience
+            )
+            _write_json(run_dir / "capture-batch.json", batch)
+            upload_result = upload_full_capture_batch(context, run_dir)
+            logger.info(
+                "星石背包正式三段采集完成: "
+                f"main={main['retained_image_count']}, "
+                f"support={support['retained_image_count']}, experience=1, dir={run_dir}, "
+                f"transport={'local-only' if upload_result is None else upload_result.message}"
+            )
+            return CustomAction.RunResult(success=True)
+        except Exception as exc:
+            logger.exception(f"星石背包正式三段采集失败: {exc}")
+            return CustomAction.RunResult(success=False)

--- a/agent/custom/action/star_backpack_capture_probe.py
+++ b/agent/custom/action/star_backpack_capture_probe.py
@@ -1,0 +1,2063 @@
+from __future__ import annotations
+
+import json
+import math
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import cv2
+import numpy as np
+from maa.agent.agent_server import AgentServer
+from maa.context import Context
+from maa.custom_action import CustomAction
+
+from utils import logger
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CAPTURE_ONLY_MODE = "capture_only"
+PAIR_PROBE_MODE = "pair_probe"
+FEEDBACK_PROBE_MODE = "feedback_probe"
+CONTINUOUS_CAPTURE_MODE = "continuous_capture"
+NORMAL_MOTION_MIN_PX = 560.0
+NORMAL_MOTION_MAX_PX = 660.0
+NORMAL_ACCEPTANCE_EPSILON_PX = 1.0
+MIN_DIRECT_OVERLAP_PX = 80
+DIRECT_OVERLAP_MARGIN_PX = 6
+DIRECT_NORMAL_MIN_SCORE = 0.70
+DIRECT_NORMAL_LOCAL_RADIUS_PX = 2
+DIRECT_HYPOTHESIS_DEDUPE_PX = 12.0
+# YuanStar's phone_9_16 profile uses a 0.079 viewport-width card radius.  In
+# the calibrated 720-wide phone captures that is about 56.9 px, or 0.34 of the
+# observed 166.5 px row cadence.  Its complete-card geometry is defined in
+# card-completeness.ts as level y-r*1.06 through name y+r*1.70.
+YUANSTAR_ROW_RADIUS_TO_PITCH_RATIO = 0.34
+YUANSTAR_ENVELOPE_TOP_RADIUS = 1.06
+YUANSTAR_ENVELOPE_BOTTOM_RADIUS = 1.70
+SEMANTIC_ENVELOPE_SAFETY_MARGIN_PX = 10.0
+SUPPORTED_MODES = frozenset(
+    {
+        CAPTURE_ONLY_MODE,
+        PAIR_PROBE_MODE,
+        FEEDBACK_PROBE_MODE,
+        CONTINUOUS_CAPTURE_MODE,
+    }
+)
+
+
+def _parse_params(raw: Any) -> dict[str, Any]:
+    if not raw:
+        return {}
+    if isinstance(raw, dict):
+        params = raw
+    elif isinstance(raw, str):
+        params = json.loads(raw)
+    else:
+        raise ValueError("custom_action_param 必须是 JSON 对象")
+    if not isinstance(params, dict):
+        raise ValueError("custom_action_param 必须是 JSON 对象")
+    return params
+
+
+def _parse_int(value: Any, name: str, *, minimum: int | None = None) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} 必须是整数")
+    try:
+        result = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} 必须是整数") from exc
+    if minimum is not None and result < minimum:
+        raise ValueError(f"{name} 必须不小于 {minimum}")
+    return result
+
+
+def _parse_rect(value: Any, name: str) -> tuple[int, int, int, int]:
+    if not isinstance(value, (list, tuple)) or len(value) != 4:
+        raise ValueError(f"{name} 必须是 [x, y, width, height]")
+    x, y, width, height = (
+        _parse_int(value[0], f"{name}[0]", minimum=0),
+        _parse_int(value[1], f"{name}[1]", minimum=0),
+        _parse_int(value[2], f"{name}[2]", minimum=1),
+        _parse_int(value[3], f"{name}[3]", minimum=1),
+    )
+    return x, y, width, height
+
+
+def _parse_swipe(value: Any, name: str = "swipe") -> tuple[int, int, int, int, int]:
+    if not isinstance(value, dict):
+        raise ValueError(f"必须显式提供 {name}")
+    start = value.get("start")
+    end = value.get("end")
+    if not isinstance(start, (list, tuple)) or len(start) != 2:
+        raise ValueError(f"{name}.start 必须是 [x, y]")
+    if not isinstance(end, (list, tuple)) or len(end) != 2:
+        raise ValueError(f"{name}.end 必须是 [x, y]")
+    return (
+        _parse_int(start[0], f"{name}.start[0]", minimum=0),
+        _parse_int(start[1], f"{name}.start[1]", minimum=0),
+        _parse_int(end[0], f"{name}.end[0]", minimum=0),
+        _parse_int(end[1], f"{name}.end[1]", minimum=0),
+        _parse_int(value.get("duration_ms"), f"{name}.duration_ms", minimum=1),
+    )
+
+
+def _parse_unit_interval(value: Any, name: str) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} 必须是 0 到 1 的数字") from exc
+    if not math.isfinite(result) or not 0 <= result <= 1:
+        raise ValueError(f"{name} 必须是 0 到 1 的数字")
+    return result
+
+
+def _parse_int_range(value: Any, name: str, minimum: int = 0) -> tuple[int, int]:
+    if not isinstance(value, (list, tuple)) or len(value) != 2:
+        raise ValueError(f"{name} 必须是 [min, max]")
+    lower = _parse_int(value[0], f"{name}[0]", minimum=minimum)
+    upper = _parse_int(value[1], f"{name}[1]", minimum=lower)
+    return lower, upper
+
+
+def _parse_positive_float(value: Any, name: str) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} 必须是正数") from exc
+    if not math.isfinite(result) or result <= 0:
+        raise ValueError(f"{name} 必须是正数")
+    return result
+
+
+def _parse_bool(value: Any, name: str, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise ValueError(f"{name} 必须是布尔值")
+    return value
+
+
+def _parse_diagnostic_feedback(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError("feedback 必须是对象")
+    safe_min, safe_max = _parse_int_range(
+        value.get("diagnostic_safe_shift_px"), "feedback.diagnostic_safe_shift_px", 1
+    )
+    expected_min, expected_max = _parse_int_range(
+        value.get("diagnostic_expected_shift_px"), "feedback.diagnostic_expected_shift_px", 1
+    )
+    physical_min, physical_max = _parse_int_range(
+        value.get("diagnostic_physical_shift_px"), "feedback.diagnostic_physical_shift_px", 1
+    )
+    target_min, target_max = _parse_int_range(
+        value.get("diagnostic_target_shift_px"), "feedback.diagnostic_target_shift_px", 1
+    )
+    normal_safe_min, normal_safe_max = _parse_int_range(
+        value.get("diagnostic_normal_safe_shift_px"),
+        "feedback.diagnostic_normal_safe_shift_px",
+        1,
+    )
+    max_micro_attempts = _parse_int(
+        value.get("max_micro_attempts"), "feedback.max_micro_attempts", minimum=0
+    )
+    if max_micro_attempts > 2:
+        raise ValueError("feedback.max_micro_attempts 不能超过 2")
+    return {
+        "max_micro_attempts": max_micro_attempts,
+        "local_search_radius_px": _parse_int(
+            value.get("local_search_radius_px"),
+            "feedback.local_search_radius_px",
+            minimum=1,
+        ),
+        "diagnostic_safe_shift_px": (safe_min, safe_max),
+        "diagnostic_expected_shift_px": (expected_min, expected_max),
+        "diagnostic_physical_shift_px": (physical_min, physical_max),
+        "diagnostic_target_shift_px": (target_min, target_max),
+        "diagnostic_normal_safe_shift_px": (normal_safe_min, normal_safe_max),
+        "diagnostic_row_pitch_px": _parse_positive_float(
+            value.get("diagnostic_row_pitch_px"), "feedback.diagnostic_row_pitch_px"
+        ),
+        "diagnostic_micro_trigger_shift_px": _parse_int(
+            value.get("diagnostic_micro_trigger_shift_px"),
+            "feedback.diagnostic_micro_trigger_shift_px",
+            minimum=1,
+        ),
+        "diagnostic_min_confidence": _parse_unit_interval(
+            value.get("diagnostic_min_confidence"),
+            "feedback.diagnostic_min_confidence",
+        ),
+        "diagnostic_min_local_overlap_score": _parse_unit_interval(
+            value.get("diagnostic_min_local_overlap_score"),
+            "feedback.diagnostic_min_local_overlap_score",
+        ),
+        "diagnostic_no_move_similarity": _parse_unit_interval(
+            value.get("diagnostic_no_move_similarity"),
+            "feedback.diagnostic_no_move_similarity",
+        ),
+        "diagnostic_no_move_shift_px": _parse_int(
+            value.get("diagnostic_no_move_shift_px"),
+            "feedback.diagnostic_no_move_shift_px",
+            minimum=0,
+        ),
+    }
+
+
+def parse_capture_probe_params(raw: Any) -> dict[str, Any]:
+    """Validate probe input without deriving any device-specific coordinates."""
+    params = _parse_params(raw)
+    mode = params.get("mode", CAPTURE_ONLY_MODE)
+    if not isinstance(mode, str) or mode not in SUPPORTED_MODES:
+        raise ValueError(
+            "mode 必须是 capture_only、pair_probe、feedback_probe 或 continuous_capture"
+        )
+
+    debug_dir = params.get("debug_dir", "debug/star-backpack-probe")
+    if not isinstance(debug_dir, str) or not debug_dir.strip():
+        raise ValueError("debug_dir 必须是非空路径字符串")
+
+    parsed: dict[str, Any] = {"mode": mode, "debug_dir": debug_dir.strip()}
+    if mode in {PAIR_PROBE_MODE, FEEDBACK_PROBE_MODE, CONTINUOUS_CAPTURE_MODE}:
+        if "compare_roi" not in params:
+            raise ValueError(f"{mode} 必须显式提供 compare_roi")
+        parsed["compare_roi"] = _parse_rect(params["compare_roi"], "compare_roi")
+
+    if mode == PAIR_PROBE_MODE:
+        parsed["swipe"] = _parse_swipe(params.get("swipe"))
+        parsed["settle_ms"] = _parse_int(
+            params.get("settle_ms"), "settle_ms", minimum=0
+        )
+
+        compare = params.get("compare", {})
+        if not isinstance(compare, dict):
+            raise ValueError("compare 必须是对象")
+        min_ratio = float(compare.get("min_overlap_ratio", 0.20))
+        max_ratio = float(compare.get("max_overlap_ratio", 0.90))
+        if (
+            not math.isfinite(min_ratio)
+            or not math.isfinite(max_ratio)
+            or not 0 < min_ratio <= max_ratio <= 1
+        ):
+            raise ValueError(
+                "compare.min_overlap_ratio 和 max_overlap_ratio 必须满足 0 < min <= max <= 1"
+            )
+        parsed["compare"] = {
+            "min_overlap_ratio": min_ratio,
+            "max_overlap_ratio": max_ratio,
+        }
+    if mode == FEEDBACK_PROBE_MODE:
+        parsed["settle_ms"] = _parse_int(
+            params.get("settle_ms"), "settle_ms", minimum=0
+        )
+        parsed["coarse_swipe"] = _parse_swipe(
+            params.get("coarse_swipe"), "coarse_swipe"
+        )
+        parsed["micro_swipe"] = _parse_swipe(
+            params.get("micro_swipe"), "micro_swipe"
+        )
+        # Calibration is opt-in so the B1d terminal-partial behaviour remains
+        # available for non-calibration feedback callers.
+        parsed["single_swipe_calibration"] = _parse_bool(
+            params.get("single_swipe_calibration"),
+            "single_swipe_calibration",
+        )
+        parsed["feedback"] = _parse_diagnostic_feedback(params.get("feedback"))
+    if mode == CONTINUOUS_CAPTURE_MODE:
+        parsed["settle_ms"] = _parse_int(
+            params.get("settle_ms"), "settle_ms", minimum=0
+        )
+        parsed["swipe"] = _parse_swipe(params.get("swipe"))
+        max_transitions = _parse_int(
+            params.get("max_transitions"), "max_transitions", minimum=1
+        )
+        if max_transitions > 50:
+            raise ValueError("max_transitions 不能超过 50")
+        parsed["max_transitions"] = max_transitions
+        parsed["feedback"] = _parse_diagnostic_feedback(params.get("feedback"))
+        game_version = params.get("game_version", "如鸢")
+        if game_version not in {"如鸢", "代号鸢"}:
+            raise ValueError("game_version 必须是 如鸢 或 代号鸢")
+        parsed["game_version"] = game_version
+    return parsed
+
+
+def _resolve_debug_base(value: str) -> Path:
+    path = Path(value)
+    return path if path.is_absolute() else REPO_ROOT / path
+
+
+def _prepare_run_directory(debug_dir: str) -> Path:
+    run_id = f"{datetime.now():%Y%m%d-%H%M%S}-{uuid.uuid4().hex[:8]}"
+    run_dir = _resolve_debug_base(debug_dir) / run_id
+    run_dir.mkdir(parents=True, exist_ok=False)
+    return run_dir
+
+
+def _write_png(path: Path, image: np.ndarray) -> None:
+    success, encoded = cv2.imencode(".png", image)
+    if not success:
+        raise RuntimeError(f"无法编码 PNG: {path}")
+    path.write_bytes(encoded.tobytes())
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def _image_metadata(image: np.ndarray, mode: str, file_name: str) -> dict[str, Any]:
+    if not isinstance(image, np.ndarray) or image.ndim < 2:
+        raise ValueError("controller screenshot 不是有效图像数组")
+    channels = int(image.shape[2]) if image.ndim >= 3 else 1
+    return {
+        "mode": mode,
+        "width": int(image.shape[1]),
+        "height": int(image.shape[0]),
+        "channels": channels,
+        "dtype": str(image.dtype),
+        "created_at": datetime.now().astimezone().isoformat(timespec="milliseconds"),
+        "file": file_name,
+    }
+
+
+def _crop_roi(image: np.ndarray, roi: tuple[int, int, int, int]) -> np.ndarray:
+    x, y, width, height = roi
+    image_height, image_width = image.shape[:2]
+    if x + width > image_width or y + height > image_height:
+        raise ValueError(f"compare_roi 超出截图范围: {roi}, image={image.shape}")
+    return image[y : y + height, x : x + width].copy()
+
+
+def _grayscale(image: np.ndarray) -> np.ndarray:
+    if image.ndim == 2:
+        return image
+    if image.ndim == 3 and image.shape[2] == 1:
+        return image[:, :, 0]
+    if image.ndim == 3 and image.shape[2] == 3:
+        return cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    if image.ndim == 3 and image.shape[2] == 4:
+        return cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+    raise ValueError(f"不支持的截图通道数: {image.shape}")
+
+
+def _prepare_compare_image(image: np.ndarray) -> np.ndarray:
+    gray = _grayscale(image).astype(np.float32)
+    return cv2.GaussianBlur(gray, (3, 3), 0)
+
+
+def _normalized_correlation(first: np.ndarray, second: np.ndarray) -> float:
+    if first.shape != second.shape or first.size == 0:
+        return 0.0
+    first_vector = first.reshape(-1).astype(np.float32)
+    second_vector = second.reshape(-1).astype(np.float32)
+    first_vector -= float(first_vector.mean())
+    second_vector -= float(second_vector.mean())
+    denominator = float(np.linalg.norm(first_vector) * np.linalg.norm(second_vector))
+    if denominator <= 1e-6:
+        return 0.0
+    return float(np.clip(first_vector @ second_vector / denominator, -1.0, 1.0))
+
+
+def compute_visual_overlap(
+    before_roi: np.ndarray,
+    after_roi: np.ndarray,
+    min_overlap_ratio: float,
+    max_overlap_ratio: float,
+) -> dict[str, float | int | None | str]:
+    """Compare page pixels only; values are diagnostic and never business decisions."""
+    if before_roi.shape[:2] != after_roi.shape[:2]:
+        raise ValueError("before/after compare ROI 的尺寸必须一致")
+    height = before_roi.shape[0]
+    if height < 2:
+        raise ValueError("compare_roi 高度至少为 2")
+
+    before = _prepare_compare_image(before_roi)
+    after = _prepare_compare_image(after_roi)
+    same_position_score = _normalized_correlation(before, after)
+    minimum = max(1, math.ceil(height * min_overlap_ratio))
+    maximum = min(height, math.floor(height * max_overlap_ratio))
+    if minimum > maximum:
+        raise ValueError("compare overlap 范围在当前 ROI 高度下为空")
+
+    best_overlap_px: int | None = None
+    best_overlap_score = -1.0
+    for overlap_px in range(minimum, maximum + 1):
+        score = _normalized_correlation(before[-overlap_px:, :], after[:overlap_px, :])
+        if score > best_overlap_score:
+            best_overlap_score = score
+            best_overlap_px = overlap_px
+
+    return {
+        "same_position_score": same_position_score,
+        "best_overlap_score": best_overlap_score,
+        "best_overlap_px": best_overlap_px,
+        "best_shift_px": height - best_overlap_px if best_overlap_px else None,
+        "classification": "diagnostic_only",
+    }
+
+
+@dataclass(frozen=True)
+class MotionEstimate:
+    """Image-only vertical motion evidence, with positive values meaning content moved up."""
+
+    shift_y: float = 0.0
+    inlier_count: int = 0
+    match_count: int = 0
+    inlier_ratio: float = 0.0
+    median_abs_deviation: float = 0.0
+    confidence: float = 0.0
+    motion_hypotheses: list[dict[str, Any]] = field(default_factory=list)
+    selected_hypothesis: dict[str, Any] | None = None
+    direction_rejected_match_count: int = 0
+    direct_normal_search: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class _MotionHypothesis:
+    matches: list[cv2.DMatch]
+    shift_y: float
+    median_abs_deviation: float
+    x_coverage: float
+    y_coverage: float
+    mean_descriptor_distance: float
+    anchor_score: float | None = None
+    anchor_height_px: int = 0
+    full_overlap_score: float | None = None
+    full_overlap_height_px: int = 0
+    full_overlap_gray_score: float | None = None
+    full_overlap_gradient_score: float | None = None
+    proposal_source: str = "orb"
+
+    def debug_dict(
+        self,
+        evidence_score: float | None = None,
+        legacy_inside_expected_range: bool | None = None,
+        inside_normal_motion_band: bool | None = None,
+        inside_physical_motion_range: bool | None = None,
+        selection_score: float | None = None,
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "shift_y": self.shift_y,
+            "match_count": len(self.matches),
+            "median_abs_deviation": self.median_abs_deviation,
+            "x_coverage": self.x_coverage,
+            "y_coverage": self.y_coverage,
+            "mean_descriptor_distance": self.mean_descriptor_distance,
+            "anchor_score": self.anchor_score,
+            "anchor_height_px": self.anchor_height_px,
+            "full_overlap_score": self.full_overlap_score,
+            "full_overlap_height_px": self.full_overlap_height_px,
+            "full_overlap_gray_score": self.full_overlap_gray_score,
+            "full_overlap_gradient_score": self.full_overlap_gradient_score,
+            "full_overlap_valid": self.full_overlap_score is not None,
+            "proposal_source": self.proposal_source,
+        }
+        if evidence_score is not None:
+            result["evidence_score"] = evidence_score
+        if legacy_inside_expected_range is not None:
+            result["inside_legacy_expected_range"] = legacy_inside_expected_range
+        if inside_normal_motion_band is not None:
+            result["inside_normal_motion_band"] = inside_normal_motion_band
+        if inside_physical_motion_range is not None:
+            result["inside_physical_motion_range"] = inside_physical_motion_range
+        if selection_score is not None:
+            result["selection_score"] = selection_score
+        return result
+
+
+def _cluster_positive_vertical_matches(
+    matches: list[cv2.DMatch],
+    before_keypoints: list[cv2.KeyPoint],
+    after_keypoints: list[cv2.KeyPoint],
+    width: int,
+    height: int,
+    tolerance_px: float = 10.0,
+) -> list[_MotionHypothesis]:
+    ordered = sorted(
+        matches,
+        key=lambda match: before_keypoints[match.queryIdx].pt[1]
+        - after_keypoints[match.trainIdx].pt[1],
+    )
+    clusters: list[list[cv2.DMatch]] = []
+    for match in ordered:
+        motion = before_keypoints[match.queryIdx].pt[1] - after_keypoints[match.trainIdx].pt[1]
+        if not clusters:
+            clusters.append([match])
+            continue
+        previous_motions = np.asarray(
+            [
+                before_keypoints[item.queryIdx].pt[1]
+                - after_keypoints[item.trainIdx].pt[1]
+                for item in clusters[-1]
+            ],
+            dtype=np.float32,
+        )
+        if abs(motion - float(np.median(previous_motions))) <= tolerance_px:
+            clusters[-1].append(match)
+        else:
+            clusters.append([match])
+
+    hypotheses: list[_MotionHypothesis] = []
+    for cluster in clusters:
+        motions = np.asarray(
+            [
+                before_keypoints[match.queryIdx].pt[1]
+                - after_keypoints[match.trainIdx].pt[1]
+                for match in cluster
+            ],
+            dtype=np.float32,
+        )
+        x_positions = np.asarray(
+            [before_keypoints[match.queryIdx].pt[0] for match in cluster], dtype=np.float32
+        )
+        y_positions = np.asarray(
+            [before_keypoints[match.queryIdx].pt[1] for match in cluster], dtype=np.float32
+        )
+        hypotheses.append(
+            _MotionHypothesis(
+                matches=cluster,
+                shift_y=float(np.median(motions)),
+                median_abs_deviation=float(np.median(np.abs(motions - np.median(motions)))),
+                x_coverage=float(np.clip((x_positions.max() - x_positions.min()) / width, 0.0, 1.0)),
+                y_coverage=float(np.clip((y_positions.max() - y_positions.min()) / height, 0.0, 1.0)),
+                mean_descriptor_distance=float(np.mean([match.distance for match in cluster])),
+            )
+        )
+    return hypotheses
+
+
+def _hypothesis_score(hypothesis: _MotionHypothesis, tolerance_px: float = 10.0) -> float:
+    coverage = 0.5 * hypothesis.x_coverage + 0.5 * hypothesis.y_coverage
+    consistency = math.exp(-hypothesis.median_abs_deviation / tolerance_px)
+    descriptor_quality = (
+        0.0
+        if hypothesis.mean_descriptor_distance is None
+        else max(0.0, 1.0 - hypothesis.mean_descriptor_distance / 256.0)
+    )
+    return len(hypothesis.matches) * (0.4 + 0.6 * coverage) * consistency * descriptor_quality
+
+
+def _direct_overlap_anchor(
+    before_roi: np.ndarray, after_roi: np.ndarray, shift_y: float
+) -> tuple[float | None, int]:
+    """Score the actual shared top strip for one shift hypothesis, without OCR."""
+    height = before_roi.shape[0]
+    shift = int(round(shift_y))
+    physical_overlap = height - shift
+    anchor_height = min(120, physical_overlap - 12)
+    if shift < 0 or anchor_height < 64 or shift + anchor_height > height:
+        return None, 0
+    before_anchor = before_roi[shift : shift + anchor_height, :]
+    after_anchor = after_roi[:anchor_height, :]
+    color_score = _normalized_correlation(
+        before_anchor.astype(np.float32), after_anchor.astype(np.float32)
+    )
+    before_gradient = cv2.Sobel(_grayscale(before_anchor), cv2.CV_32F, 0, 1)
+    after_gradient = cv2.Sobel(_grayscale(after_anchor), cv2.CV_32F, 0, 1)
+    gradient_score = _normalized_correlation(before_gradient, after_gradient)
+    return 0.65 * color_score + 0.35 * gradient_score, anchor_height
+
+
+def _apply_direct_overlap_anchors(
+    hypotheses: list[_MotionHypothesis],
+    before_roi: np.ndarray,
+    after_roi: np.ndarray,
+) -> None:
+    for hypothesis in hypotheses:
+        hypothesis.anchor_score, hypothesis.anchor_height_px = _direct_overlap_anchor(
+            before_roi, after_roi, hypothesis.shift_y
+        )
+        (
+            hypothesis.full_overlap_score,
+            hypothesis.full_overlap_height_px,
+            hypothesis.full_overlap_gray_score,
+            hypothesis.full_overlap_gradient_score,
+        ) = _full_overlap_direct_validation(before_roi, after_roi, hypothesis.shift_y)
+
+
+def _full_overlap_direct_validation(
+    before_roi: np.ndarray,
+    after_roi: np.ndarray,
+    shift_y: float,
+    prepared: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray] | None = None,
+) -> tuple[float | None, int, float | None, float | None]:
+    """Validate the complete physically shared region for one motion hypothesis.
+
+    A fixed strip can sit entirely inside one repeated card row.  This compares
+    every available shared pixel (except a small capture-edge margin), without
+    interpreting card content or invoking OCR.
+    """
+    height = before_roi.shape[0]
+    shift = int(round(shift_y))
+    available_overlap_height = height - shift
+    overlap_height = available_overlap_height - (2 * DIRECT_OVERLAP_MARGIN_PX)
+    if (
+        shift < 0
+        or overlap_height < MIN_DIRECT_OVERLAP_PX
+        or shift + DIRECT_OVERLAP_MARGIN_PX + overlap_height > height
+    ):
+        return None, 0, None, None
+    if prepared is None:
+        before_gray = _grayscale(before_roi).astype(np.float32)
+        after_gray = _grayscale(after_roi).astype(np.float32)
+        before_gradient = cv2.Sobel(before_gray, cv2.CV_32F, 0, 1)
+        after_gradient = cv2.Sobel(after_gray, cv2.CV_32F, 0, 1)
+    else:
+        before_gray, after_gray, before_gradient, after_gradient = prepared
+    before_slice = slice(
+        shift + DIRECT_OVERLAP_MARGIN_PX, height - DIRECT_OVERLAP_MARGIN_PX
+    )
+    after_slice = slice(
+        DIRECT_OVERLAP_MARGIN_PX, available_overlap_height - DIRECT_OVERLAP_MARGIN_PX
+    )
+    gray_score = _normalized_correlation(
+        before_gray[before_slice, :], after_gray[after_slice, :]
+    )
+    gradient_score = _normalized_correlation(
+        before_gradient[before_slice, :], after_gradient[after_slice, :]
+    )
+    return (
+        0.45 * gray_score + 0.55 * gradient_score,
+        overlap_height,
+        gray_score,
+        gradient_score,
+    )
+
+
+def _find_direct_normal_band_candidate(
+    before_roi: np.ndarray, after_roi: np.ndarray
+) -> tuple[_MotionHypothesis | None, dict[str, Any]]:
+    """Propose one robust direct-motion branch inside the calibrated normal band."""
+    started = time.perf_counter()
+    minimum_shift = int(NORMAL_MOTION_MIN_PX)
+    maximum_shift = min(int(NORMAL_MOTION_MAX_PX), before_roi.shape[0] - 1)
+    before_gray = _grayscale(before_roi).astype(np.float32)
+    after_gray = _grayscale(after_roi).astype(np.float32)
+    prepared = (
+        before_gray,
+        after_gray,
+        cv2.Sobel(before_gray, cv2.CV_32F, 0, 1),
+        cv2.Sobel(after_gray, cv2.CV_32F, 0, 1),
+    )
+    scores: dict[int, tuple[float, int, float, float]] = {}
+    for shift in range(minimum_shift, maximum_shift + 1):
+        score, overlap_height, gray_score, gradient_score = _full_overlap_direct_validation(
+            before_roi, after_roi, float(shift), prepared
+        )
+        if (
+            score is not None
+            and gray_score is not None
+            and gradient_score is not None
+            and overlap_height >= MIN_DIRECT_OVERLAP_PX
+        ):
+            scores[shift] = (score, overlap_height, gray_score, gradient_score)
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    diagnostics: dict[str, Any] = {
+        "enabled": True,
+        "min_shift_px": minimum_shift,
+        "max_shift_px": maximum_shift,
+        "best_shift_px": None,
+        "best_score": None,
+        "best_rank_score": None,
+        "candidate_injected": False,
+        "elapsed_ms": elapsed_ms,
+    }
+    if not scores:
+        return None, diagnostics
+
+    def rank(shift: int) -> float:
+        score = scores[shift][0]
+        neighborhood = [
+            scores[nearby][0]
+            for nearby in range(
+                shift - DIRECT_NORMAL_LOCAL_RADIUS_PX,
+                shift + DIRECT_NORMAL_LOCAL_RADIUS_PX + 1,
+            )
+            if nearby in scores
+        ]
+        return 0.70 * score + 0.30 * float(np.mean(neighborhood))
+
+    best_shift = max(scores, key=rank)
+    best_score, overlap_height, gray_score, gradient_score = scores[best_shift]
+    best_rank_score = rank(best_shift)
+    diagnostics.update(
+        {
+            "best_shift_px": best_shift,
+            "best_score": best_score,
+            "best_rank_score": best_rank_score,
+        }
+    )
+    if best_score < DIRECT_NORMAL_MIN_SCORE:
+        return None, diagnostics
+    anchor_score, anchor_height_px = _direct_overlap_anchor(
+        before_roi, after_roi, float(best_shift)
+    )
+    if anchor_score is None:
+        return None, diagnostics
+    diagnostics["candidate_injected"] = True
+    return (
+        _MotionHypothesis(
+            matches=[],
+            shift_y=float(best_shift),
+            median_abs_deviation=0.0,
+            x_coverage=1.0,
+            y_coverage=1.0,
+            mean_descriptor_distance=None,
+            anchor_score=anchor_score,
+            anchor_height_px=anchor_height_px,
+            full_overlap_score=best_score,
+            full_overlap_height_px=overlap_height,
+            full_overlap_gray_score=gray_score,
+            full_overlap_gradient_score=gradient_score,
+            proposal_source="direct_normal_band",
+        ),
+        diagnostics,
+    )
+
+
+def _merge_direct_normal_candidate(
+    orb_hypotheses: list[_MotionHypothesis], direct_candidate: _MotionHypothesis | None
+) -> list[_MotionHypothesis]:
+    """Avoid duplicate normal branches while preserving real ORB support when present."""
+    if direct_candidate is None:
+        return orb_hypotheses
+    for index, hypothesis in enumerate(orb_hypotheses):
+        if abs(hypothesis.shift_y - direct_candidate.shift_y) <= DIRECT_HYPOTHESIS_DEDUPE_PX:
+            orb_hypotheses[index] = _MotionHypothesis(
+                matches=hypothesis.matches,
+                shift_y=direct_candidate.shift_y,
+                median_abs_deviation=hypothesis.median_abs_deviation,
+                x_coverage=hypothesis.x_coverage,
+                y_coverage=hypothesis.y_coverage,
+                mean_descriptor_distance=hypothesis.mean_descriptor_distance,
+                anchor_score=direct_candidate.anchor_score,
+                anchor_height_px=direct_candidate.anchor_height_px,
+                full_overlap_score=direct_candidate.full_overlap_score,
+                full_overlap_height_px=direct_candidate.full_overlap_height_px,
+                full_overlap_gray_score=direct_candidate.full_overlap_gray_score,
+                full_overlap_gradient_score=direct_candidate.full_overlap_gradient_score,
+                proposal_source="merged",
+            )
+            return orb_hypotheses
+    return [*orb_hypotheses, direct_candidate]
+
+
+def _has_validated_direct_normal_support(
+    hypothesis: _MotionHypothesis,
+    direct_normal_search: dict[str, Any] | None,
+) -> bool:
+    """Keep strict direct evidence when it is merged with sparse ORB support."""
+    if hypothesis.proposal_source == "direct_normal_band":
+        return True
+    if hypothesis.proposal_source != "merged" or not direct_normal_search:
+        return False
+    if direct_normal_search.get("candidate_injected") is not True:
+        return False
+    best_shift_px = direct_normal_search.get("best_shift_px")
+    best_score = direct_normal_search.get("best_score")
+    if (
+        not isinstance(best_shift_px, (int, float))
+        or abs(float(best_shift_px) - hypothesis.shift_y) > DIRECT_HYPOTHESIS_DEDUPE_PX
+        or not isinstance(best_score, (int, float))
+        or best_score < DIRECT_NORMAL_MIN_SCORE
+    ):
+        return False
+    return True
+
+
+def _select_motion_hypothesis(
+    hypotheses: list[_MotionHypothesis],
+    expected_shift_px: tuple[int, int] | None,
+    physical_shift_px: tuple[int, int] | None,
+    direct_normal_search: dict[str, Any] | None = None,
+    *,
+    terminal_confirmed: bool = False,
+    terminal_max_shift_px: float | None = None,
+) -> tuple[_MotionHypothesis | None, dict[str, Any] | None, list[dict[str, Any]]]:
+    """Prefer a verified normal-motion branch before terminal fallback.
+
+    ``expected_shift_px`` remains a legacy diagnostic field only.  It cannot
+    overrule full shared-pixel evidence or turn a low periodic alias into the
+    selected normal page motion.
+    """
+    evidence_scores = [_hypothesis_score(hypothesis) for hypothesis in hypotheses]
+    maximum_evidence = max(evidence_scores, default=1.0)
+    scored_hypotheses: list[dict[str, Any]] = []
+    for hypothesis, evidence_score in zip(hypotheses, evidence_scores):
+        legacy_inside_expected_range = (
+            expected_shift_px is not None
+            and expected_shift_px[0] <= hypothesis.shift_y <= expected_shift_px[1]
+        )
+        inside_normal_motion_band = (
+            NORMAL_MOTION_MIN_PX <= hypothesis.shift_y <= NORMAL_MOTION_MAX_PX
+        )
+        inside_physical_motion_range = (
+            physical_shift_px is None
+            or physical_shift_px[0] <= hypothesis.shift_y <= physical_shift_px[1]
+        )
+        evidence_quality = evidence_score / maximum_evidence
+        anchor_quality = hypothesis.anchor_score if hypothesis.anchor_score is not None else 0.0
+        full_overlap_quality = (
+            hypothesis.full_overlap_score
+            if hypothesis.full_overlap_score is not None
+            else 0.0
+        )
+        robust_feature_support = min(1.0, len(hypothesis.matches) / 20.0)
+        robust_feature_support *= math.exp(-hypothesis.median_abs_deviation / 12.0)
+        robust_feature_support *= (
+            0.0
+            if hypothesis.mean_descriptor_distance is None
+            else max(0.0, 1.0 - hypothesis.mean_descriptor_distance / 256.0)
+        )
+        normal_selection_score = (
+            0.55 * full_overlap_quality
+            + 0.25 * anchor_quality
+            + 0.10 * hypothesis.x_coverage
+            + 0.10 * robust_feature_support
+        )
+        fallback_selection_score = (
+            0.40 * evidence_quality
+            + 0.35 * anchor_quality
+            + 0.25 * full_overlap_quality
+        )
+        scored_hypotheses.append(
+            {
+                "hypothesis": hypothesis,
+                "evidence_score": evidence_score,
+                "legacy_inside_expected_range": legacy_inside_expected_range,
+                "inside_normal_motion_band": inside_normal_motion_band,
+                "inside_physical_motion_range": inside_physical_motion_range,
+                "normal_selection_score": normal_selection_score,
+                "fallback_selection_score": fallback_selection_score,
+            }
+        )
+    debug_hypotheses = [
+        item["hypothesis"].debug_dict(
+            item["evidence_score"],
+            item["legacy_inside_expected_range"],
+            item["inside_normal_motion_band"],
+            item["inside_physical_motion_range"],
+        )
+        for item in scored_hypotheses
+    ]
+    physical_candidates = [
+        item for item in scored_hypotheses if item["inside_physical_motion_range"]
+    ]
+    if not physical_candidates:
+        return None, None, debug_hypotheses
+    terminal_candidates = [
+        item
+        for item in physical_candidates
+        if (
+            terminal_confirmed
+            and terminal_max_shift_px is not None
+            and 0 < item["hypothesis"].shift_y <= terminal_max_shift_px
+            and len(item["hypothesis"].matches) >= 4
+            and item["hypothesis"].median_abs_deviation <= 12.0
+            and item["hypothesis"].full_overlap_score is not None
+            and item["hypothesis"].full_overlap_score >= DIRECT_NORMAL_MIN_SCORE
+            and item["hypothesis"].full_overlap_height_px >= MIN_DIRECT_OVERLAP_PX
+            and item["hypothesis"].anchor_score is not None
+            and item["hypothesis"].anchor_score >= DIRECT_NORMAL_MIN_SCORE
+        )
+    ]
+    normal_candidates = [
+        item
+        for item in physical_candidates
+        if (
+            item["inside_normal_motion_band"]
+            and item["hypothesis"].full_overlap_score is not None
+            and item["hypothesis"].full_overlap_height_px >= MIN_DIRECT_OVERLAP_PX
+            and item["hypothesis"].anchor_score is not None
+            and item["hypothesis"].median_abs_deviation <= 12.0
+            and (
+                len(item["hypothesis"].matches) >= 3
+                or _has_validated_direct_normal_support(
+                    item["hypothesis"], direct_normal_search
+                )
+            )
+        )
+    ]
+    if terminal_confirmed:
+        if not terminal_candidates:
+            return None, None, debug_hypotheses
+        selected_item = max(
+            terminal_candidates, key=lambda item: item["fallback_selection_score"]
+        )
+        selection_mode = "terminal_confirmed_short_motion"
+        selected_by = "terminal_confirmed_evidence"
+        selection_score = selected_item["fallback_selection_score"]
+    elif normal_candidates:
+        selected_item = max(normal_candidates, key=lambda item: item["normal_selection_score"])
+        selection_mode = "normal_motion_full_overlap"
+        selected_by = "full_overlap_score"
+        selection_score = selected_item["normal_selection_score"]
+    else:
+        selected_item = max(
+            physical_candidates, key=lambda item: item["fallback_selection_score"]
+        )
+        selection_mode = "terminal_fallback"
+        selected_by = "fallback_evidence"
+        selection_score = selected_item["fallback_selection_score"]
+    selected = selected_item["hypothesis"]
+    selected_reason = selected.debug_dict(
+        selected_item["evidence_score"],
+        selected_item["legacy_inside_expected_range"],
+        selected_item["inside_normal_motion_band"],
+        selected_item["inside_physical_motion_range"],
+        selection_score,
+    )
+    selected_reason.update(
+        {
+            "selection_mode": selection_mode,
+            "normal_motion_candidate_count": len(normal_candidates),
+            "selected_by": selected_by,
+            "fallback_used": selection_mode != "normal_motion_full_overlap",
+        }
+    )
+    return selected, selected_reason, debug_hypotheses
+
+
+def _direct_candidate_motion_estimate(
+    selected: _MotionHypothesis,
+    selected_reason: dict[str, Any],
+    debug_hypotheses: list[dict[str, Any]],
+    direction_rejected_match_count: int,
+    direct_normal_search: dict[str, Any],
+) -> MotionEstimate:
+    """Expose a direct-only proposal without inventing ORB/RANSAC evidence."""
+    return MotionEstimate(
+        shift_y=selected.shift_y,
+        confidence=float(selected.full_overlap_score or 0.0),
+        motion_hypotheses=debug_hypotheses,
+        selected_hypothesis=selected_reason,
+        direction_rejected_match_count=direction_rejected_match_count,
+        direct_normal_search=direct_normal_search,
+    )
+
+
+def estimate_vertical_motion(
+    before_roi: np.ndarray,
+    after_roi: np.ndarray,
+    expected_shift_px: tuple[int, int] | None = None,
+    physical_shift_px: tuple[int, int] | None = None,
+    *,
+    terminal_confirmed: bool = False,
+    terminal_max_shift_px: float | None = None,
+) -> MotionEstimate:
+    """Estimate one vertical page shift with hypothesis clustering then cluster RANSAC.
+
+    ``shift_y`` is positive when content in ``after_roi`` moved upward relative to
+    ``before_roi``. ORB remains the feature proposer; a narrow direct search
+    supplements only the calibrated normal band when ORB misses that branch.
+    """
+    if before_roi.shape[:2] != after_roi.shape[:2]:
+        raise ValueError("before/after compare ROI 的尺寸必须一致")
+    height, width = before_roi.shape[:2]
+    if height < 32 or width < 32:
+        return MotionEstimate()
+    direct_candidate, direct_normal_search = _find_direct_normal_band_candidate(
+        before_roi, after_roi
+    )
+
+    before = cv2.GaussianBlur(_grayscale(before_roi), (3, 3), 0)
+    after = cv2.GaussianBlur(_grayscale(after_roi), (3, 3), 0)
+    orb = cv2.ORB_create(nfeatures=1600, fastThreshold=12)
+    before_keypoints, before_descriptors = orb.detectAndCompute(before, None)
+    after_keypoints, after_descriptors = orb.detectAndCompute(after, None)
+    if before_descriptors is None or after_descriptors is None:
+        hypotheses = _merge_direct_normal_candidate([], direct_candidate)
+        selected, selected_reason, debug_hypotheses = _select_motion_hypothesis(
+            hypotheses,
+            expected_shift_px,
+            physical_shift_px,
+            direct_normal_search,
+            terminal_confirmed=terminal_confirmed,
+            terminal_max_shift_px=terminal_max_shift_px,
+        )
+        if selected is not None and selected_reason is not None:
+            return _direct_candidate_motion_estimate(
+                selected,
+                selected_reason,
+                debug_hypotheses,
+                0,
+                direct_normal_search,
+            )
+        return MotionEstimate(direct_normal_search=direct_normal_search)
+
+    raw_matches = cv2.BFMatcher(cv2.NORM_HAMMING).knnMatch(
+        before_descriptors, after_descriptors, k=2
+    )
+    maximum_dx = max(12.0, width * 0.08)
+    maximum_dy = height * 0.95
+    positive_matches: list[cv2.DMatch] = []
+    direction_rejected_match_count = 0
+    for pair in raw_matches:
+        if len(pair) != 2:
+            continue
+        first, second = pair
+        if first.distance >= 0.72 * second.distance:
+            continue
+        source = before_keypoints[first.queryIdx].pt
+        target = after_keypoints[first.trainIdx].pt
+        dx = target[0] - source[0]
+        motion_y = source[1] - target[1]
+        if abs(dx) > maximum_dx or abs(motion_y) > maximum_dy:
+            continue
+        # The feedback probe only scrolls the list upward. Near-zero evidence is
+        # intentionally left to the independent same-position no_move check.
+        if motion_y <= 0:
+            direction_rejected_match_count += 1
+            continue
+        positive_matches.append(first)
+    if len(positive_matches) < 3:
+        hypotheses = _merge_direct_normal_candidate([], direct_candidate)
+        selected, selected_reason, debug_hypotheses = _select_motion_hypothesis(
+            hypotheses,
+            expected_shift_px,
+            physical_shift_px,
+            direct_normal_search,
+            terminal_confirmed=terminal_confirmed,
+            terminal_max_shift_px=terminal_max_shift_px,
+        )
+        if selected is not None and selected_reason is not None:
+            return _direct_candidate_motion_estimate(
+                selected,
+                selected_reason,
+                debug_hypotheses,
+                direction_rejected_match_count,
+                direct_normal_search,
+            )
+        return MotionEstimate(
+            match_count=len(positive_matches),
+            direction_rejected_match_count=direction_rejected_match_count,
+            direct_normal_search=direct_normal_search,
+        )
+
+    hypotheses = _cluster_positive_vertical_matches(
+        positive_matches, before_keypoints, after_keypoints, width, height
+    )
+    _apply_direct_overlap_anchors(hypotheses, before_roi, after_roi)
+    hypotheses = _merge_direct_normal_candidate(hypotheses, direct_candidate)
+    selected, selected_reason, debug_hypotheses = _select_motion_hypothesis(
+        hypotheses,
+        expected_shift_px,
+        physical_shift_px,
+        direct_normal_search,
+        terminal_confirmed=terminal_confirmed,
+        terminal_max_shift_px=terminal_max_shift_px,
+    )
+    if selected is None or selected_reason is None:
+        return MotionEstimate(
+            match_count=len(positive_matches),
+            motion_hypotheses=debug_hypotheses,
+            direction_rejected_match_count=direction_rejected_match_count,
+            direct_normal_search=direct_normal_search,
+        )
+    if (
+        not selected.matches
+        or (
+            len(selected.matches) < 4
+            and _has_validated_direct_normal_support(selected, direct_normal_search)
+        )
+    ):
+        return _direct_candidate_motion_estimate(
+            selected,
+            selected_reason,
+            debug_hypotheses,
+            direction_rejected_match_count,
+            direct_normal_search,
+        )
+    source_points = np.float32(
+        [before_keypoints[match.queryIdx].pt for match in selected.matches]
+    ).reshape(-1, 1, 2)
+    target_points = np.float32(
+        [after_keypoints[match.trainIdx].pt for match in selected.matches]
+    ).reshape(-1, 1, 2)
+    transform, inlier_mask = cv2.estimateAffinePartial2D(
+        source_points,
+        target_points,
+        method=cv2.RANSAC,
+        ransacReprojThreshold=3.0,
+        maxIters=3000,
+        confidence=0.995,
+        refineIters=10,
+    )
+    if transform is None or inlier_mask is None:
+        return MotionEstimate(
+            match_count=len(selected.matches),
+            motion_hypotheses=debug_hypotheses,
+            selected_hypothesis=selected_reason,
+            direction_rejected_match_count=direction_rejected_match_count,
+            direct_normal_search=direct_normal_search,
+        )
+
+    mask = inlier_mask.reshape(-1).astype(bool)
+    inlier_count = int(mask.sum())
+    if not inlier_count:
+        return MotionEstimate(
+            match_count=len(selected.matches),
+            motion_hypotheses=debug_hypotheses,
+            selected_hypothesis=selected_reason,
+            direction_rejected_match_count=direction_rejected_match_count,
+            direct_normal_search=direct_normal_search,
+        )
+    motions = np.asarray(
+        [
+            before_keypoints[match.queryIdx].pt[1]
+            - after_keypoints[match.trainIdx].pt[1]
+            for match, is_inlier in zip(selected.matches, mask)
+            if is_inlier
+        ],
+        dtype=np.float32,
+    )
+    median_motion = float(np.median(motions))
+    mad = float(np.median(np.abs(motions - median_motion)))
+    translation_x = float(transform[0, 2])
+    translation_y = float(transform[1, 2])
+    inlier_ratio = inlier_count / len(selected.matches)
+    count_evidence = min(1.0, inlier_count / 30.0)
+    consistency = math.exp(-mad / 12.0)
+    horizontal_evidence = math.exp(-abs(translation_x) / maximum_dx)
+    confidence = float(
+        np.clip(count_evidence * inlier_ratio * consistency * horizontal_evidence, 0.0, 1.0)
+    )
+    shift_y = -translation_y
+    if shift_y <= 0:
+        confidence = 0.0
+    return MotionEstimate(
+        shift_y=shift_y,
+        inlier_count=inlier_count,
+        match_count=len(selected.matches),
+        inlier_ratio=inlier_ratio,
+        median_abs_deviation=mad,
+        confidence=confidence,
+        motion_hypotheses=debug_hypotheses,
+        selected_hypothesis=selected_reason,
+        direction_rejected_match_count=direction_rejected_match_count,
+        direct_normal_search=direct_normal_search,
+    )
+
+
+def _local_overlap_confirmation(
+    before_roi: np.ndarray,
+    after_roi: np.ndarray,
+    predicted_shift_y: float,
+    search_radius_px: int,
+) -> tuple[float | None, int | None, bool]:
+    """Confirm only around ORB's estimate; never re-scan the complete offset range."""
+    before = _prepare_compare_image(before_roi)
+    after = _prepare_compare_image(after_roi)
+    height = before.shape[0]
+    center = int(round(predicted_shift_y))
+    if center < 0 or center >= height:
+        return None, None, False
+    candidates = range(
+        max(0, center - search_radius_px),
+        min(height - 1, center + search_radius_px) + 1,
+    )
+    best_score = -1.0
+    best_shift: int | None = None
+    for shift in candidates:
+        score = _normalized_correlation(before[shift:, :], after[: height - shift, :])
+        if score > best_score:
+            best_score = score
+            best_shift = shift
+    if best_shift is None:
+        return None, None, False
+    return best_score, best_shift, True
+
+
+def _estimate_row_lattice(roi: np.ndarray, row_pitch_px: float) -> dict[str, Any]:
+    """Estimate the current frame's four-column row phase without OCR.
+
+    The phase score samples the expected disc and text-edge heights around each
+    row centre.  Each frame is estimated independently, avoiding any
+    accumulation of historical swipe error.
+    """
+    height = roi.shape[0]
+    pitch = float(row_pitch_px)
+    radius = pitch * YUANSTAR_ROW_RADIUS_TO_PITCH_RATIO
+    gray = _grayscale(roi).astype(np.float32)
+    energy = np.mean(np.abs(cv2.Sobel(gray, cv2.CV_32F, 0, 1)), axis=1)
+    phase_limit = max(1, int(round(pitch)))
+
+    def sample(position: float) -> float:
+        center = int(round(position))
+        start = max(0, center - 2)
+        end = min(height, center + 3)
+        return float(np.mean(energy[start:end])) if end > start else 0.0
+
+    def phase_score(phase: int) -> float:
+        values: list[float] = []
+        center = float(phase)
+        while center < height + pitch:
+            if -radius <= center <= height + radius:
+                # YuanStar's disc, level and name ROI boundaries are all
+                # visible geometric evidence even though no text is read.
+                values.append(
+                    0.35 * sample(center - radius)
+                    + 0.35 * sample(center + radius)
+                    + 0.15 * sample(center - radius * 0.77)
+                    + 0.15 * sample(center + radius * 1.39)
+                )
+            center += pitch
+        return float(np.mean(values)) if values else 0.0
+
+    best_phase = max(range(phase_limit), key=phase_score)
+    phase_evidence = phase_score(best_phase)
+    first_center = float(best_phase)
+    while first_center - pitch > -pitch:
+        first_center -= pitch
+    centers: list[float] = []
+    center = first_center
+    while center <= height + pitch:
+        if -pitch <= center <= height + pitch:
+            centers.append(round(center, 2))
+        center += pitch
+    return {
+        "row_centers": centers,
+        "row_pitch_px": pitch,
+        "radius_px": radius,
+        "phase_px": float(best_phase),
+        "phase_evidence": phase_evidence,
+    }
+
+
+def evaluate_semantic_row_overlap(
+    prev_roi: np.ndarray,
+    candidate_roi: np.ndarray,
+    actual_shift_px: float,
+    row_pitch_px: float,
+    *,
+    prev_row_centers: list[float] | None = None,
+    candidate_row_centers: list[float] | None = None,
+) -> dict[str, Any]:
+    """Decide whether a complete YuanStar OCR row exists in both shared areas."""
+    started = time.perf_counter()
+    height = prev_roi.shape[0]
+    shift = float(np.clip(actual_shift_px, 0.0, float(height)))
+    physical_overlap_px = max(0.0, float(height) - shift)
+    prev_lattice = _estimate_row_lattice(prev_roi, row_pitch_px)
+    candidate_lattice = _estimate_row_lattice(candidate_roi, row_pitch_px)
+    prev_centers = prev_row_centers if prev_row_centers is not None else prev_lattice["row_centers"]
+    candidate_centers = (
+        candidate_row_centers
+        if candidate_row_centers is not None
+        else candidate_lattice["row_centers"]
+    )
+    radius = float(prev_lattice["radius_px"])
+    top_offset = -YUANSTAR_ENVELOPE_TOP_RADIUS * radius
+    bottom_offset = YUANSTAR_ENVELOPE_BOTTOM_RADIUS * radius
+    safety_margin = SEMANTIC_ENVELOPE_SAFETY_MARGIN_PX
+    prev_shared = (shift, float(height))
+    candidate_shared = (0.0, physical_overlap_px)
+    phase_tolerance = max(12.0, row_pitch_px * 0.12)
+    full_rows: list[dict[str, Any]] = []
+    ambiguous_rows: list[dict[str, Any]] = []
+    for prev_center in prev_centers:
+        expected_candidate_center = prev_center - shift
+        if not candidate_centers:
+            continue
+        candidate_center = min(
+            candidate_centers, key=lambda center: abs(center - expected_candidate_center)
+        )
+        phase_delta = abs(candidate_center - expected_candidate_center)
+        if phase_delta > phase_tolerance:
+            continue
+        prev_envelope = (prev_center + top_offset, prev_center + bottom_offset)
+        candidate_envelope = (
+            candidate_center + top_offset,
+            candidate_center + bottom_offset,
+        )
+        clearance = min(
+            prev_envelope[0] - prev_shared[0],
+            prev_shared[1] - prev_envelope[1],
+            candidate_envelope[0] - candidate_shared[0],
+            candidate_shared[1] - candidate_envelope[1],
+        )
+        row_evidence = {
+            "prev_center_y": round(prev_center, 2),
+            "candidate_center_y": round(candidate_center, 2),
+            "phase_delta_px": round(phase_delta, 2),
+            "clearance_px": round(clearance, 2),
+        }
+        if clearance >= safety_margin:
+            full_rows.append(row_evidence)
+        elif clearance >= 0:
+            ambiguous_rows.append(row_evidence)
+    if full_rows:
+        state = "definitely_full_row"
+        required = True
+        reason = "complete_envelope_in_both_shared_regions"
+        candidates = full_rows
+    elif ambiguous_rows:
+        state = "ambiguous"
+        required = True
+        reason = "envelope_near_shared_region_boundary"
+        candidates = ambiguous_rows
+    else:
+        state = "definitely_no_full_row"
+        required = False
+        reason = "no_complete_envelope_in_both_shared_regions"
+        candidates = []
+    return {
+        "visual_overlap": physical_overlap_px > 0,
+        "physical_overlap_px": physical_overlap_px,
+        "actual_shift_px": shift,
+        "row_pitch_px": row_pitch_px,
+        "prev_row_centers": prev_centers,
+        "candidate_row_centers": candidate_centers,
+        "ocr_row_envelope": {
+            "top_offset": top_offset,
+            "bottom_offset": bottom_offset,
+            "safety_margin_px": safety_margin,
+            "source": "yuanstar_runtime_geometry",
+        },
+        "semantic_overlap_state": state,
+        "ocr_overlap_pair_required": required,
+        "full_row_candidates": candidates,
+        "reason": reason,
+        "runtime_ms": (time.perf_counter() - started) * 1000,
+        "row_lattice": {
+            "prev": prev_lattice,
+            "candidate": candidate_lattice,
+        },
+    }
+
+
+def _has_reliable_direct_normal_motion(estimate: MotionEstimate) -> bool:
+    """Accept a selected direct-normal branch only after every direct check agrees.
+
+    This is intentionally independent from ORB/RANSAC confidence.  It is not a
+    confidence bypass: the selected hypothesis, full-overlap validation,
+    anchor, direct-search injection, and the two local-shift values must all
+    describe the same normal-band motion.
+    """
+    selected = estimate.selected_hypothesis
+    direct_search = estimate.direct_normal_search
+    if not selected or not direct_search:
+        return False
+    if selected.get("selection_mode") != "normal_motion_full_overlap":
+        return False
+    if selected.get("fallback_used") is not False:
+        return False
+    if selected.get("inside_normal_motion_band") is not True:
+        return False
+    if selected.get("inside_physical_motion_range") is not True:
+        return False
+    if selected.get("proposal_source") not in {"direct_normal_band", "merged"}:
+        return False
+    if selected.get("full_overlap_valid") is not True:
+        return False
+    full_overlap_score = selected.get("full_overlap_score")
+    anchor_score = selected.get("anchor_score")
+    if (
+        not isinstance(full_overlap_score, (int, float))
+        or full_overlap_score < DIRECT_NORMAL_MIN_SCORE
+        or not isinstance(anchor_score, (int, float))
+        or anchor_score < DIRECT_NORMAL_MIN_SCORE
+    ):
+        return False
+    if direct_search.get("candidate_injected") is not True:
+        return False
+    best_shift_px = direct_search.get("best_shift_px")
+    if not isinstance(best_shift_px, (int, float)):
+        return False
+    return abs(float(best_shift_px) - estimate.shift_y) <= DIRECT_HYPOTHESIS_DEDUPE_PX
+
+
+def evaluate_feedback_candidate(
+    prev_roi: np.ndarray,
+    candidate_roi: np.ndarray,
+    feedback: dict[str, Any],
+) -> dict[str, Any]:
+    """Evaluate one candidate against the same accepted previous screenshot.
+
+    The diagnostic window is supplied by the caller. It is intentionally not a
+    production threshold: a later calibrated collector may choose different
+    values without changing the image-estimation semantics.
+    """
+    estimate = estimate_vertical_motion(
+        prev_roi,
+        candidate_roi,
+        feedback["diagnostic_expected_shift_px"],
+        feedback["diagnostic_physical_shift_px"],
+    )
+    same_position_score = _normalized_correlation(
+        _prepare_compare_image(prev_roi), _prepare_compare_image(candidate_roi)
+    )
+    local_overlap_score, local_overlap_shift_px, local_overlap_valid = _local_overlap_confirmation(
+        prev_roi,
+        candidate_roi,
+        estimate.shift_y,
+        feedback["local_search_radius_px"],
+    )
+    safe_min, safe_max = feedback["diagnostic_safe_shift_px"]
+    normal_safe_min, normal_safe_max = feedback["diagnostic_normal_safe_shift_px"]
+    target_min, target_max = feedback["diagnostic_target_shift_px"]
+    # The bottom of the configured normal window is deliberately tolerant of
+    # estimation noise.  It is not the efficiency floor: 520--600 px remains
+    # a one-shot correction band, and 600 px is the lower acceptable edge.
+    acceptable_normal_min = max(normal_safe_min, target_min - 10)
+    physical_min, physical_max = feedback["diagnostic_physical_shift_px"]
+    row_pitch_px = feedback["diagnostic_row_pitch_px"]
+    semantic_overlap = evaluate_semantic_row_overlap(
+        prev_roi, candidate_roi, estimate.shift_y, row_pitch_px
+    )
+    visual_overlap_rows = semantic_overlap["physical_overlap_px"] / row_pitch_px
+    orb_confidence_passed = (
+        estimate.confidence >= feedback["diagnostic_min_confidence"]
+    )
+    direct_normal_evidence_passed = _has_reliable_direct_normal_motion(estimate)
+    has_reliable_motion = orb_confidence_passed or direct_normal_evidence_passed
+    if orb_confidence_passed and direct_normal_evidence_passed:
+        motion_reliability_mode = "orb_and_direct"
+    elif orb_confidence_passed:
+        motion_reliability_mode = "orb_confidence"
+    elif direct_normal_evidence_passed:
+        motion_reliability_mode = "direct_normal_full_overlap"
+    else:
+        motion_reliability_mode = "unreliable"
+    motion_reliability = {
+        "reliable": has_reliable_motion,
+        "mode": motion_reliability_mode,
+        "orb_confidence_passed": orb_confidence_passed,
+        "direct_normal_evidence_passed": direct_normal_evidence_passed,
+    }
+    has_reliable_overlap = (
+        has_reliable_motion
+        and local_overlap_valid
+        and local_overlap_score is not None
+        and local_overlap_score >= feedback["diagnostic_min_local_overlap_score"]
+    )
+    no_move = (
+        same_position_score >= feedback["diagnostic_no_move_similarity"]
+        and (
+            # Preserve the original no-move fail-safe: even a periodic direct
+            # candidate cannot overrule strong same-position evidence when
+            # ORB/RANSAC did not independently confirm movement.
+            not orb_confidence_passed
+            or abs(estimate.shift_y) <= feedback["diagnostic_no_move_shift_px"]
+        )
+    )
+    if no_move:
+        # Two identical frames are not an adjacent image pair, regardless of
+        # how many complete rows happen to be visible in their shared region.
+        semantic_overlap = {
+            **semantic_overlap,
+            "semantic_overlap_state": "not_applicable_no_move",
+            "ocr_overlap_pair_required": False,
+            "reason": "no_move_not_an_adjacent_pair",
+        }
+    elif not has_reliable_overlap:
+        # Without trustworthy motion and local-overlap evidence, the two
+        # screenshots cannot be treated as an adjacent pair. Keep the raw
+        # physical and lattice diagnostics for review, but do not infer OCR
+        # pair semantics from a coincidental geometric envelope.
+        semantic_overlap = {
+            **semantic_overlap,
+            "semantic_overlap_state": "not_applicable_unreliable_motion",
+            "ocr_overlap_pair_required": False,
+            "full_row_candidates": [],
+            "reason": "unreliable_motion_not_an_adjacent_pair",
+        }
+    ocr_overlap_pair_required = semantic_overlap["ocr_overlap_pair_required"]
+    accepted = (
+        has_reliable_overlap
+        and (
+            acceptable_normal_min - NORMAL_ACCEPTANCE_EPSILON_PX
+            <= estimate.shift_y
+            <= normal_safe_max
+        )
+    )
+    if accepted:
+        reason = "diagnostic_only"
+        relation: str | None = "overlap" if ocr_overlap_pair_required else None
+        if target_min <= estimate.shift_y <= target_max:
+            efficiency_status = "semantic_zero_overlap_target"
+        else:
+            efficiency_status = "semantic_zero_overlap_acceptable"
+    elif no_move:
+        reason = "bottom_no_move"
+        relation = None
+        efficiency_status = "terminal_partial"
+    elif (
+        has_reliable_overlap
+        and physical_min <= estimate.shift_y < feedback["diagnostic_micro_trigger_shift_px"]
+    ):
+        reason = "terminal_partial_candidate"
+        relation = None
+        efficiency_status = "terminal_partial"
+    elif (
+        has_reliable_overlap
+        and feedback["diagnostic_micro_trigger_shift_px"]
+        <= estimate.shift_y < acceptable_normal_min
+    ):
+        reason = "efficiency_correction_required"
+        relation = None
+        efficiency_status = "conservative"
+    else:
+        reason = "unsafe_gap_risk"
+        relation = None
+        efficiency_status = "aggressive" if estimate.shift_y > normal_safe_max else "conservative"
+    return {
+        "shift_estimate": asdict(estimate),
+        "same_position_score": same_position_score,
+        "local_overlap_score": local_overlap_score,
+        "local_overlap_shift_px": local_overlap_shift_px,
+        "local_overlap_valid": local_overlap_valid,
+        "motion_reliability": motion_reliability,
+        "target_shift_range": list(feedback["diagnostic_target_shift_px"]),
+        "safe_shift_range": list(feedback["diagnostic_normal_safe_shift_px"]),
+        "physical_shift_range": list(feedback["diagnostic_physical_shift_px"]),
+        "efficiency_status": efficiency_status,
+        "row_pitch_px": row_pitch_px,
+        "visual_overlap_rows": visual_overlap_rows,
+        "visual_overlap": semantic_overlap["visual_overlap"],
+        "physical_overlap_px": semantic_overlap["physical_overlap_px"],
+        "actual_shift_px": semantic_overlap["actual_shift_px"],
+        "ocr_row_envelope": semantic_overlap["ocr_row_envelope"],
+        "semantic_overlap_state": semantic_overlap["semantic_overlap_state"],
+        "ocr_overlap_pair_required": ocr_overlap_pair_required,
+        "full_row_candidates": semantic_overlap["full_row_candidates"],
+        "semantic_overlap_reason": semantic_overlap["reason"],
+        "semantic_overlap_runtime_ms": semantic_overlap["runtime_ms"],
+        "row_lattice": semantic_overlap["row_lattice"],
+        "true_shift_rows": estimate.shift_y / row_pitch_px,
+        "accepted": accepted,
+        "relation": relation,
+        "reason": reason,
+        "classification": "diagnostic_only",
+    }
+
+
+def _feedback_metrics_contract(evaluation: dict[str, Any]) -> dict[str, Any]:
+    """Project an internal feedback evaluation onto the stable JSON contract.
+
+    Candidate selection, row-lattice geometry, thresholds, and retry reasons
+    remain local implementation details.  B2 only needs the final transition
+    decision plus a small amount of non-duplicated diagnostic evidence.
+    """
+    return {
+        "accepted": evaluation["accepted"],
+        "relation": evaluation["relation"],
+        "ocr_overlap_pair_required": evaluation["ocr_overlap_pair_required"],
+        "semantic_overlap_state": evaluation["semantic_overlap_state"],
+        "section_complete": evaluation["section_complete"],
+        "image_pair": evaluation["image_pair"],
+        "diagnostics": {
+            "actual_shift_px": evaluation["actual_shift_px"],
+            "motion_reliability": evaluation["motion_reliability"]["mode"],
+            "physical_overlap_px": evaluation["physical_overlap_px"],
+        },
+    }
+
+
+def _evaluate_continuous_transition(
+    prev_roi: np.ndarray,
+    candidate_roi: np.ndarray,
+    feedback: dict[str, Any],
+) -> dict[str, Any]:
+    """Reuse the B1 decision and expose only its stable transition contract."""
+    evaluation = evaluate_feedback_candidate(prev_roi, candidate_roi, feedback)
+    semantic_state = evaluation["semantic_overlap_state"]
+    return _feedback_metrics_contract(
+        {
+            **evaluation,
+            "section_complete": semantic_state == "not_applicable_no_move",
+            "image_pair": None,
+        }
+    )
+
+
+def _is_capture_safe_progress(
+    transition: dict[str, Any], feedback: dict[str, Any]
+) -> bool:
+    """Accept reliable forward progress even when B1 marks it inefficient.
+
+    B1's ``accepted`` flag deliberately includes its target-stride efficiency
+    window. B2 instead needs a conservative capture rule: retain any reliable
+    positive movement that cannot have skipped a row according to B1's
+    already-configured physical and normal-safe bounds.
+    """
+    if transition["diagnostics"]["motion_reliability"] == "unreliable":
+        return False
+    actual_shift_px = transition["diagnostics"]["actual_shift_px"]
+    if not isinstance(actual_shift_px, (int, float)):
+        return False
+    physical_min, _ = feedback["diagnostic_physical_shift_px"]
+    _, normal_safe_max = feedback["diagnostic_normal_safe_shift_px"]
+    return (
+        physical_min
+        <= actual_shift_px
+        <= normal_safe_max + NORMAL_ACCEPTANCE_EPSILON_PX
+    )
+
+
+def _terminal_confirmed_overlap_pair_required(
+    prev_roi: np.ndarray,
+    candidate_roi: np.ndarray,
+    feedback: dict[str, Any],
+) -> bool:
+    """Recheck only the final retained pair after the next frame confirms bottom.
+
+    Normal continuous transitions keep their normal-band protection. This narrow
+    path can select a shorter ORB-supported movement only after the following
+    transition has independently established ``bottom_no_move``.
+    """
+    physical_min, _ = feedback["diagnostic_physical_shift_px"]
+    terminal_max_shift_px = feedback["diagnostic_micro_trigger_shift_px"]
+    estimate = estimate_vertical_motion(
+        prev_roi,
+        candidate_roi,
+        feedback["diagnostic_expected_shift_px"],
+        feedback["diagnostic_physical_shift_px"],
+        terminal_confirmed=True,
+        terminal_max_shift_px=float(terminal_max_shift_px),
+    )
+    selected = estimate.selected_hypothesis
+    if (
+        selected is None
+        or not physical_min <= estimate.shift_y <= terminal_max_shift_px
+        or estimate.match_count < 4
+        or estimate.inlier_count < 4
+        or estimate.confidence < feedback["diagnostic_min_confidence"]
+        or selected.get("proposal_source") == "direct_normal_band"
+        or selected.get("full_overlap_score", 0.0) < DIRECT_NORMAL_MIN_SCORE
+        or selected.get("anchor_score", 0.0) < DIRECT_NORMAL_MIN_SCORE
+    ):
+        return False
+    local_score, _, local_valid = _local_overlap_confirmation(
+        prev_roi,
+        candidate_roi,
+        estimate.shift_y,
+        feedback["local_search_radius_px"],
+    )
+    if (
+        not local_valid
+        or local_score is None
+        or local_score < feedback["diagnostic_min_local_overlap_score"]
+    ):
+        return False
+    semantic_overlap = evaluate_semantic_row_overlap(
+        prev_roi,
+        candidate_roi,
+        estimate.shift_y,
+        feedback["diagnostic_row_pitch_px"],
+    )
+    if (
+        semantic_overlap["semantic_overlap_state"]
+        in {"definitely_full_row", "ambiguous"}
+        and semantic_overlap["ocr_overlap_pair_required"] is True
+    ):
+        return True
+
+    # The terminal pair can lose the prior frame's lattice phase when the list
+    # header leaves the compare ROI. The selected ORB/RANSAC transform and the
+    # full/local-overlap checks above already establish the two frames' pixel
+    # correspondence. Re-anchor only the independently detected candidate rows
+    # through that transform, then reuse the unchanged row-envelope decision.
+    candidate_row_centers = semantic_overlap["candidate_row_centers"]
+    if not candidate_row_centers:
+        return False
+    reanchored_semantic_overlap = evaluate_semantic_row_overlap(
+        prev_roi,
+        candidate_roi,
+        estimate.shift_y,
+        feedback["diagnostic_row_pitch_px"],
+        prev_row_centers=[center + estimate.shift_y for center in candidate_row_centers],
+        candidate_row_centers=candidate_row_centers,
+    )
+    return (
+        reanchored_semantic_overlap["semantic_overlap_state"]
+        in {"definitely_full_row", "ambiguous"}
+        and reanchored_semantic_overlap["ocr_overlap_pair_required"] is True
+    )
+
+
+def _gesture_payload(gesture: tuple[int, int, int, int, int]) -> dict[str, Any]:
+    return {
+        "start": [gesture[0], gesture[1]],
+        "end": [gesture[2], gesture[3]],
+        "duration_ms": gesture[4],
+    }
+
+
+@AgentServer.custom_action("StarBackpackCaptureProbe")
+class StarBackpackCaptureProbe(CustomAction):
+    """Capture a star-backpack screen with opt-in visual-only diagnostic probes."""
+
+    def _capture(self, context: Context) -> np.ndarray:
+        image = context.tasker.controller.post_screencap().wait().get()
+        if image is None:
+            raise RuntimeError("星石背包截图失败")
+        if not isinstance(image, np.ndarray):
+            raise RuntimeError("controller screenshot 不是 NumPy 图像")
+        return image
+
+    def _run_continuous_capture(
+        self,
+        context: Context,
+        params: dict[str, Any],
+        run_dir: Path,
+        initial: np.ndarray,
+    ) -> dict[str, Any]:
+        """Capture adjacent main-star pages using one B1-evaluated swipe at a time."""
+        retained_images = ["capture-00.png"]
+        adjacent_relations: list[dict[str, str]] = []
+        _write_png(run_dir / retained_images[0], initial)
+        prev = initial
+        prev_roi = _crop_roi(prev, params["compare_roi"])
+        transition_count = 0
+        failed_transition: int | None = None
+        stop_reason = "transition_limit_reached"
+        success = False
+        last_semantic_overlap_state: str | None = None
+        last_motion_reliability: str | None = None
+        last_actual_shift_px: float | None = None
+        last_retained_pair_rois: tuple[np.ndarray, np.ndarray] | None = None
+
+        for transition_index in range(1, params["max_transitions"] + 1):
+            # The B2 loop is deliberately a single gesture.  Retry and motion
+            # policy remain B1 concerns; this layer never adds a second swipe.
+            context.tasker.controller.post_swipe(*params["swipe"]).wait()
+            transition_count = transition_index
+            if params["settle_ms"]:
+                time.sleep(params["settle_ms"] / 1000)
+            candidate = self._capture(context)
+            candidate_roi = _crop_roi(candidate, params["compare_roi"])
+            transition = _evaluate_continuous_transition(
+                prev_roi, candidate_roi, params["feedback"]
+            )
+            last_semantic_overlap_state = transition["semantic_overlap_state"]
+            last_motion_reliability = transition["diagnostics"][
+                "motion_reliability"
+            ]
+            last_actual_shift_px = transition["diagnostics"]["actual_shift_px"]
+
+            if _is_capture_safe_progress(transition, params["feedback"]):
+                previous_image = retained_images[-1]
+                image_name = f"capture-{len(retained_images):02d}.png"
+                _write_png(run_dir / image_name, candidate)
+                retained_images.append(image_name)
+                last_retained_pair_rois = (prev_roi, candidate_roi)
+                if transition["ocr_overlap_pair_required"] is True:
+                    adjacent_relations.append(
+                        {
+                            "previous_image": previous_image,
+                            "current_image": image_name,
+                            "relation": "overlap",
+                        }
+                    )
+                prev = candidate
+                prev_roi = candidate_roi
+                continue
+
+            if last_semantic_overlap_state == "not_applicable_no_move":
+                if len(retained_images) > 1:
+                    success = True
+                    stop_reason = "bottom_no_move"
+                    final_pair = (retained_images[-2], retained_images[-1])
+                    final_pair_has_relation = any(
+                        relation["previous_image"] == final_pair[0]
+                        and relation["current_image"] == final_pair[1]
+                        for relation in adjacent_relations
+                    )
+                    if (
+                        not final_pair_has_relation
+                        and last_retained_pair_rois is not None
+                        and _terminal_confirmed_overlap_pair_required(
+                            last_retained_pair_rois[0],
+                            last_retained_pair_rois[1],
+                            params["feedback"],
+                        )
+                    ):
+                        adjacent_relations.append(
+                            {
+                                "previous_image": final_pair[0],
+                                "current_image": final_pair[1],
+                                "relation": "overlap",
+                            }
+                        )
+                else:
+                    stop_reason = "no_move_before_progress"
+                    failed_transition = transition_index
+            elif last_semantic_overlap_state == "not_applicable_unreliable_motion":
+                stop_reason = "unreliable_transition"
+                failed_transition = transition_index
+            else:
+                stop_reason = "rejected_transition"
+                failed_transition = transition_index
+            if stop_reason in {"unreliable_transition", "rejected_transition"}:
+                _write_png(
+                    run_dir / f"failed-candidate-{transition_index:02d}.png",
+                    candidate,
+                )
+            break
+        else:
+            failed_transition = transition_count
+
+        session = {
+            "success": success,
+            "stop_reason": stop_reason,
+            "retained_images": retained_images,
+            "retained_image_count": len(retained_images),
+            "adjacent_relations": adjacent_relations,
+            "transition_count": transition_count,
+            "failed_transition": failed_transition,
+            "diagnostics": {
+                "last_semantic_overlap_state": last_semantic_overlap_state,
+                "last_motion_reliability": last_motion_reliability,
+                "last_actual_shift_px": last_actual_shift_px,
+            },
+        }
+        _write_json(run_dir / "session.json", session)
+        return session
+
+    def _run_feedback_probe(
+        self,
+        context: Context,
+        params: dict[str, Any],
+        run_dir: Path,
+        prev: np.ndarray,
+    ) -> dict[str, Any]:
+        """Keep every retry anchored to ``prev`` so gesture error cannot accumulate.
+
+        Incorrect: assume an expected X-pixel stride and chain page1+X, page2+X.
+        Correct: compare the accepted real prev image with each real candidate,
+        accepting a candidate only after its direct image evidence is safe.
+        """
+        _write_png(run_dir / "prev.png", prev)
+        prev_roi = _crop_roi(prev, params["compare_roi"])
+        _write_png(run_dir / "prev-roi.png", prev_roi)
+
+        attempts: list[dict[str, Any]] = []
+        final_candidate: np.ndarray | None = None
+        final_candidate_roi: np.ndarray | None = None
+        final_evaluation: dict[str, Any] | None = None
+        candidate_index = 0
+
+        def capture_candidate(
+            gesture: tuple[int, int, int, int, int], stage: str
+        ) -> tuple[np.ndarray, np.ndarray, dict[str, Any]]:
+            nonlocal candidate_index
+            context.tasker.controller.post_swipe(*gesture).wait()
+            if params["settle_ms"]:
+                time.sleep(params["settle_ms"] / 1000)
+            candidate = self._capture(context)
+            candidate_roi = _crop_roi(candidate, params["compare_roi"])
+            evaluation = evaluate_feedback_candidate(
+                prev_roi, candidate_roi, params["feedback"]
+            )
+            estimate = evaluation["shift_estimate"]
+            attempts.append(
+                {
+                    "stage": stage,
+                    "gesture": _gesture_payload(gesture),
+                    "shift_y": estimate["shift_y"],
+                    "confidence": estimate["confidence"],
+                    "local_overlap_score": evaluation["local_overlap_score"],
+                    "reason": evaluation["reason"],
+                }
+            )
+            # A no-move confirmation is evidence only. It is never promoted to
+            # a business capture, while a positive candidate is retained for
+            # diagnostic review and potential terminal-partial acceptance.
+            if evaluation["reason"] != "bottom_no_move":
+                candidate_index += 1
+                attempt_name = f"candidate-{candidate_index:02d}"
+                _write_png(run_dir / f"{attempt_name}.png", candidate)
+                _write_png(run_dir / f"{attempt_name}-roi.png", candidate_roi)
+            return candidate, candidate_roi, evaluation
+
+        candidate, candidate_roi, evaluation = capture_candidate(
+            params["coarse_swipe"], "coarse"
+        )
+        if (
+            not params["single_swipe_calibration"]
+            and evaluation["reason"] == "terminal_partial_candidate"
+        ):
+            terminal_candidate = candidate
+            terminal_candidate_roi = candidate_roi
+            terminal_evaluation = evaluation
+            # The confirmation deliberately compares against the temporary
+            # terminal candidate, not ``prev``. If it no longer moves, the
+            # temporary candidate is the final page evidence to accept.
+            confirmation_gesture = params["micro_swipe"]
+            context.tasker.controller.post_swipe(*confirmation_gesture).wait()
+            if params["settle_ms"]:
+                time.sleep(params["settle_ms"] / 1000)
+            confirmation = self._capture(context)
+            confirmation_roi = _crop_roi(confirmation, params["compare_roi"])
+            confirmation_evaluation = evaluate_feedback_candidate(
+                terminal_candidate_roi, confirmation_roi, params["feedback"]
+            )
+            confirmation_estimate = confirmation_evaluation["shift_estimate"]
+            attempts.append(
+                {
+                    "stage": "terminal_confirmation",
+                    "gesture": _gesture_payload(confirmation_gesture),
+                    "shift_y": confirmation_estimate["shift_y"],
+                    "confidence": confirmation_estimate["confidence"],
+                    "local_overlap_score": confirmation_evaluation["local_overlap_score"],
+                    "reason": confirmation_evaluation["reason"],
+                }
+            )
+            if confirmation_evaluation["reason"] == "bottom_no_move":
+                final_candidate = terminal_candidate
+                final_candidate_roi = terminal_candidate_roi
+                final_evaluation = dict(terminal_evaluation)
+                final_evaluation.update(
+                    {
+                        "accepted": True,
+                        "relation": (
+                            "overlap"
+                            if terminal_evaluation["ocr_overlap_pair_required"]
+                            else None
+                        ),
+                        "reason": "diagnostic_only",
+                        "efficiency_status": "terminal_partial",
+                        "terminal_partial_confirmed": True,
+                        "section_complete": True,
+                    }
+                )
+            else:
+                # The confirmation did move, so it becomes a fresh candidate
+                # against the original accepted prev. No assumed stride is
+                # carried forward from the temporary terminal frame.
+                candidate = confirmation
+                candidate_roi = confirmation_roi
+                evaluation = evaluate_feedback_candidate(
+                    prev_roi, candidate_roi, params["feedback"]
+                )
+                if evaluation["reason"] != "bottom_no_move":
+                    candidate_index += 1
+                    attempt_name = f"candidate-{candidate_index:02d}"
+                    _write_png(run_dir / f"{attempt_name}.png", candidate)
+                    _write_png(run_dir / f"{attempt_name}-roi.png", candidate_roi)
+                final_candidate = candidate
+                final_candidate_roi = candidate_roi
+                final_evaluation = evaluation
+
+        if final_evaluation is None:
+            final_candidate = candidate
+            final_candidate_roi = candidate_roi
+            final_evaluation = evaluation
+        # A normal page with only 3-ish visual rows advanced needs exactly one
+        # corrective micro swipe.  Each attempt remains measured from ``prev``;
+        # no accumulated page-to-page assumption is allowed here.
+        if (
+            not params["single_swipe_calibration"]
+            and final_evaluation["reason"] == "efficiency_correction_required"
+        ):
+            final_candidate, final_candidate_roi, final_evaluation = capture_candidate(
+                params["micro_swipe"], "efficiency_micro"
+            )
+
+        if (
+            not params["single_swipe_calibration"]
+            and final_evaluation["reason"]
+            in {"move_too_small", "efficiency_correction_required"}
+        ):
+            final_evaluation["reason"] = "unsafe_gap_risk"
+        if final_evaluation["reason"] == "bottom_no_move":
+            if not params["single_swipe_calibration"]:
+                final_candidate = None
+                final_candidate_roi = None
+            final_evaluation["section_complete"] = True
+        else:
+            final_evaluation.setdefault("section_complete", False)
+        if final_candidate is not None and final_candidate_roi is not None:
+            _write_png(run_dir / "candidate.png", final_candidate)
+            _write_png(run_dir / "candidate-roi.png", final_candidate_roi)
+        final_evaluation["attempts"] = attempts
+        final_evaluation["gesture_count"] = len(attempts)
+        final_evaluation["single_swipe_calibration"] = params[
+            "single_swipe_calibration"
+        ]
+        final_evaluation["image_pair"] = (
+            {
+                "previous_image_id": "prev.png",
+                "current_image_id": "candidate.png",
+            }
+            if (
+                final_evaluation["accepted"]
+                and final_evaluation["ocr_overlap_pair_required"]
+                and final_candidate is not None
+            )
+            else None
+        )
+        metrics = _feedback_metrics_contract(final_evaluation)
+        _write_json(run_dir / "feedback-metrics.json", metrics)
+        return metrics
+
+    def run(
+        self, context: Context, argv: CustomAction.RunArg
+    ) -> CustomAction.RunResult:
+        try:
+            params = parse_capture_probe_params(argv.custom_action_param)
+            run_dir = _prepare_run_directory(params["debug_dir"])
+            before = self._capture(context)
+
+            if params["mode"] == CAPTURE_ONLY_MODE:
+                _write_png(run_dir / "capture.png", before)
+                metadata = _image_metadata(before, CAPTURE_ONLY_MODE, "capture.png")
+                _write_json(run_dir / "metadata.json", metadata)
+                logger.info(
+                    "星石背包截图探针已保存: "
+                    f"size={metadata['width']}x{metadata['height']}, "
+                    f"channels={metadata['channels']}, dtype={metadata['dtype']}, "
+                    f"dir={run_dir}"
+                )
+                return CustomAction.RunResult(success=True)
+
+            if params["mode"] == PAIR_PROBE_MODE:
+                _write_png(run_dir / "before.png", before)
+                context.tasker.controller.post_swipe(*params["swipe"]).wait()
+                if params["settle_ms"]:
+                    time.sleep(params["settle_ms"] / 1000)
+                after = self._capture(context)
+                _write_png(run_dir / "after.png", after)
+
+                before_roi = _crop_roi(before, params["compare_roi"])
+                after_roi = _crop_roi(after, params["compare_roi"])
+                _write_png(run_dir / "before-roi.png", before_roi)
+                _write_png(run_dir / "after-roi.png", after_roi)
+                metrics = compute_visual_overlap(
+                    before_roi,
+                    after_roi,
+                    params["compare"]["min_overlap_ratio"],
+                    params["compare"]["max_overlap_ratio"],
+                )
+                _write_json(run_dir / "metrics.json", metrics)
+                logger.info(
+                    "星石背包 pair_probe 完成（仅诊断）: "
+                    f"same={metrics['same_position_score']:.4f}, "
+                    f"overlap={metrics['best_overlap_score']:.4f}, "
+                    f"overlap_px={metrics['best_overlap_px']}, dir={run_dir}"
+                )
+                return CustomAction.RunResult(success=True)
+            elif params["mode"] == FEEDBACK_PROBE_MODE:
+                metrics = self._run_feedback_probe(context, params, run_dir, before)
+                logger.info(
+                    "星石背包 feedback_probe 完成（仅诊断）: "
+                    f"accepted={metrics['accepted']}, "
+                    f"section_complete={metrics['section_complete']}, dir={run_dir}"
+                )
+                return CustomAction.RunResult(success=True)
+
+            session = self._run_continuous_capture(context, params, run_dir, before)
+            logger.info(
+                "星石背包连续采集完成: "
+                f"success={session['success']}, stop={session['stop_reason']}, "
+                f"images={session['retained_image_count']}, dir={run_dir}"
+            )
+            return CustomAction.RunResult(success=session["success"])
+        except Exception as exc:
+            logger.exception(f"星石背包截图探针失败: {exc}")
+            return CustomAction.RunResult(success=False)

--- a/agent/custom/action/star_capture_transport.py
+++ b/agent/custom/action/star_capture_transport.py
@@ -1,0 +1,295 @@
+"""Private B4 main-star transport: manifest construction and multipart upload only."""
+from __future__ import annotations
+
+import json
+import re
+import time
+import uuid
+from pathlib import Path
+from typing import Any, TypeAlias
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+from custom.action.inventory_reporting import (
+    AUTO_UPLOAD_MODE,
+    UploadResult,
+    UploadSettings,
+    _retry_wait,
+    read_upload_settings,
+)
+
+
+STAR_CAPTURE_PATH = "/open-api/star/captures"
+_IMAGE_NAME = re.compile(r"^capture-\d{2}\.png$")
+_SAFE_CAPTURE_ID = re.compile(r"^[A-Za-z0-9:_-]{1,160}$")
+_SECTION_NAMES = ("main", "support", "experience")
+_WireImage: TypeAlias = tuple[str, Path]
+
+
+def build_main_capture_manifest(
+    run_dir: Path, session: dict[str, Any], game_version: str
+) -> tuple[dict[str, Any], list[Path]]:
+    """Build the smoke manifest without changing B capture diagnostics or images."""
+    if session.get("success") is not True or session.get("stop_reason") != "bottom_no_move":
+        raise ValueError("只有 bottom_no_move 成功主星采集可以上传")
+    if game_version not in {"如鸢", "代号鸢"}:
+        raise ValueError("game_version 必须是 如鸢 或 代号鸢")
+    image_names = session.get("retained_images")
+    if not isinstance(image_names, list) or not image_names:
+        raise ValueError("连续采集缺少 retained_images")
+    if len(set(image_names)) != len(image_names):
+        raise ValueError("连续采集 retained_images 重复")
+
+    resolved_dir = run_dir.resolve()
+    paths: list[Path] = []
+    for name in image_names:
+        if not isinstance(name, str) or not _IMAGE_NAME.fullmatch(name):
+            raise ValueError("连续采集图片文件名无效")
+        path = (resolved_dir / name).resolve()
+        if path.parent != resolved_dir or not path.is_file():
+            raise ValueError("连续采集图片不存在")
+        paths.append(path)
+
+    # run_dir is immutable for one successful capture, so retries retain this ID
+    # without adding mutable transport fields to session.json.
+    capture_id = "star-" + uuid.uuid5(uuid.NAMESPACE_URL, resolved_dir.as_uri()).hex
+    source_id_by_name = {
+        path.name: f"{capture_id}:main:{index:03d}"
+        for index, path in enumerate(paths)
+    }
+    relations: list[dict[str, str]] = []
+    raw_relations = session.get("adjacent_relations")
+    if not isinstance(raw_relations, list):
+        raise ValueError("连续采集 adjacent_relations 无效")
+    for relation in raw_relations:
+        if not isinstance(relation, dict) or relation.get("relation") != "overlap":
+            raise ValueError("连续采集 overlap 关系无效")
+        previous = source_id_by_name.get(str(relation.get("previous_image", "")))
+        current = source_id_by_name.get(str(relation.get("current_image", "")))
+        if not previous or not current:
+            raise ValueError("连续采集 overlap 未指向保留图片")
+        relations.append(
+            {
+                "previous_source_image_id": previous,
+                "current_source_image_id": current,
+                "relation": "overlap",
+            }
+        )
+    return (
+        {
+            "schema_version": 1,
+            "capture_id": capture_id,
+            "game_version": game_version,
+            "section": "main",
+            "stop_reason": "bottom_no_move",
+            "images": [
+                {
+                    "source_image_id": source_id_by_name[path.name],
+                    "source_order": index + 1,
+                    "file_name": path.name,
+                }
+                for index, path in enumerate(paths)
+            ],
+            "adjacent_relations": relations,
+        },
+        paths,
+    )
+
+
+def build_full_capture_manifest(run_dir: Path, batch: dict[str, Any]) -> tuple[dict[str, Any], list[_WireImage]]:
+    """Translate the canonical local CaptureBatchV1 at the transport boundary."""
+    if batch.get("schemaVersion") != 1 or batch.get("source") != "maayuan":
+        raise ValueError("capture-batch.json 不是 CaptureBatchV1")
+    capture_id = str(batch.get("captureId", "")).strip()
+    game_version = str(batch.get("gameVersion", "")).strip()
+    sections = batch.get("sections")
+    if not _SAFE_CAPTURE_ID.fullmatch(capture_id) or game_version not in {"如鸢", "代号鸢"}:
+        raise ValueError("capture-batch.json 顶层字段无效")
+    if not isinstance(sections, dict) or set(sections) != set(_SECTION_NAMES):
+        raise ValueError("capture-batch.json 必须包含完整的三段 sections")
+
+    resolved_run_dir = run_dir.resolve()
+    seen_ids: set[str] = set()
+    seen_orders: set[int] = set()
+    seen_wire_names: set[str] = set()
+    wire_images: list[_WireImage] = []
+    wire_sections: dict[str, dict[str, Any]] = {}
+    for section_name in _SECTION_NAMES:
+        section = sections[section_name]
+        if not isinstance(section, dict):
+            raise ValueError(f"{section_name} section 无效")
+        images = section.get("images")
+        relations = section.get("adjacentRelations")
+        complete = section.get("complete")
+        stop_reason = section.get("stopReason")
+        if not isinstance(images, list) or not isinstance(relations, list):
+            raise ValueError(f"{section_name} section 图片或关联无效")
+        expected_stop = "single_capture" if section_name == "experience" else "bottom_no_move"
+        if complete is not True or stop_reason != expected_stop:
+            raise ValueError(f"{section_name} section 未完成或停止原因无效")
+        if section_name == "experience" and (len(images) != 1 or relations):
+            raise ValueError("experience 必须恰有一张图片且无关联")
+        if section_name != "experience" and not images:
+            raise ValueError(f"{section_name} 必须至少有一张图片")
+
+        source_orders: dict[str, int] = {}
+        converted_images: list[dict[str, Any]] = []
+        for index, image in enumerate(images):
+            if not isinstance(image, dict):
+                raise ValueError(f"{section_name} 图片无效")
+            source_id = str(image.get("sourceImageId", "")).strip()
+            source_order = image.get("sourceOrder")
+            local_name = str(image.get("fileName", "")).strip()
+            expected_local_name = f"{section_name}/capture-{index:02d}.png"
+            if (
+                not _SAFE_CAPTURE_ID.fullmatch(source_id)
+                or not isinstance(source_order, int)
+                or source_order < 1
+                or local_name != expected_local_name
+                or source_id in seen_ids
+                or source_order in seen_orders
+            ):
+                raise ValueError(f"{section_name} 图片字段无效")
+            local_path = (resolved_run_dir / local_name).resolve()
+            if local_path.parent != (resolved_run_dir / section_name) or not local_path.is_file():
+                raise ValueError(f"{section_name} 图片不存在或越界")
+            wire_name = f"{section_name}-{index:03d}.png"
+            if wire_name in seen_wire_names:
+                raise ValueError("传输图片名重复")
+            seen_ids.add(source_id)
+            seen_orders.add(source_order)
+            seen_wire_names.add(wire_name)
+            source_orders[source_id] = source_order
+            wire_images.append((wire_name, local_path))
+            converted_images.append({"source_image_id": source_id, "source_order": source_order, "file_name": wire_name})
+        converted_relations: list[dict[str, str]] = []
+        relation_keys: set[tuple[str, str]] = set()
+        for relation in relations:
+            if not isinstance(relation, dict):
+                raise ValueError(f"{section_name} overlap 关系无效")
+            previous = str(relation.get("previousSourceImageId", "")).strip()
+            current = str(relation.get("currentSourceImageId", "")).strip()
+            key = (previous, current)
+            if (
+                relation.get("relation") != "overlap"
+                or previous not in source_orders
+                or current not in source_orders
+                or source_orders[current] != source_orders[previous] + 1
+                or key in relation_keys
+            ):
+                raise ValueError(f"{section_name} overlap 关系无效")
+            relation_keys.add(key)
+            converted_relations.append({"previous_source_image_id": previous, "current_source_image_id": current, "relation": "overlap"})
+        wire_sections[section_name] = {"images": converted_images, "adjacent_relations": converted_relations, "complete": True, "stop_reason": expected_stop}
+    if sorted(seen_orders) != list(range(1, len(seen_orders) + 1)):
+        raise ValueError("CaptureBatchV1 source_order 必须全局连续")
+    return ({"schema_version": 1, "capture_id": capture_id, "source": "maayuan", "game_version": game_version, "sections": wire_sections}, wire_images)
+
+
+def _multipart_body(manifest: dict[str, Any], paths: list[Path] | list[_WireImage]) -> tuple[bytes, str]:
+    boundary = "----MaaYuanStarCapture" + uuid.uuid4().hex
+    chunks: list[bytes] = []
+
+    def add(headers: list[str], payload: bytes) -> None:
+        chunks.append(("--" + boundary + "\r\n").encode("ascii"))
+        chunks.extend((header + "\r\n").encode("utf-8") for header in headers)
+        chunks.append(b"\r\n")
+        chunks.append(payload)
+        chunks.append(b"\r\n")
+
+    add(
+        [
+            'Content-Disposition: form-data; name="manifest"',
+            "Content-Type: application/json; charset=utf-8",
+        ],
+        json.dumps(manifest, ensure_ascii=False, separators=(",", ":")).encode("utf-8"),
+    )
+    for item in paths:
+        wire_name, path = item if isinstance(item, tuple) else (item.name, item)
+        add(
+            [
+                f'Content-Disposition: form-data; name="files"; filename="{wire_name}"',
+                "Content-Type: image/png",
+            ],
+            path.read_bytes(),
+        )
+    chunks.append(("--" + boundary + "--\r\n").encode("ascii"))
+    return b"".join(chunks), boundary
+
+
+def upload_full_capture_batch(
+    context: Any,
+    run_dir: Path,
+    *,
+    timeout_seconds: float = 20.0,
+    max_attempts: int = 3,
+) -> UploadResult | None:
+    """Upload a complete local three-section batch only in existing auto-upload mode."""
+    settings = read_upload_settings(context)
+    if settings.mode != AUTO_UPLOAD_MODE:
+        return None
+    try:
+        batch = json.loads((run_dir / "capture-batch.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("无法读取 capture-batch.json") from exc
+    manifest, paths = build_full_capture_manifest(run_dir, batch)
+    return upload_main_capture_manifest(manifest, paths, settings, timeout_seconds, max_attempts)
+
+
+def upload_main_capture_manifest(
+    manifest: dict[str, Any],
+    paths: list[Path] | list[_WireImage],
+    settings: UploadSettings,
+    timeout_seconds: float = 20.0,
+    max_attempts: int = 3,
+) -> UploadResult:
+    if settings.mode != AUTO_UPLOAD_MODE or not settings.token:
+        raise ValueError("只有配置 Token 的自动上报模式可以上传星石截图")
+    if timeout_seconds <= 0 or max_attempts < 1:
+        raise ValueError("星石截图上传参数无效")
+    body, boundary = _multipart_body(manifest, paths)
+    request = urllib_request.Request(
+        settings.base_url + STAR_CAPTURE_PATH,
+        data=body,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {settings.token}",
+            "Content-Type": f"multipart/form-data; boundary={boundary}",
+            "User-Agent": "MaaYuan-StarCapture/1",
+        },
+        method="POST",
+    )
+    for attempt in range(max_attempts):
+        try:
+            with urllib_request.urlopen(request, timeout=timeout_seconds) as response:
+                status_code = int(getattr(response, "status", response.getcode()))
+                response_body = response.read().decode("utf-8", errors="replace")
+            if 200 <= status_code < 300:
+                return UploadResult(True, status_code, f"HTTP {status_code}")
+            if status_code >= 500 and attempt + 1 < max_attempts:
+                _retry_wait(attempt)
+                continue
+            return UploadResult(False, status_code, _response_message(status_code, response_body))
+        except urllib_error.HTTPError as exc:
+            response_body = exc.read().decode("utf-8", errors="replace")
+            if exc.code >= 500 and attempt + 1 < max_attempts:
+                _retry_wait(attempt)
+                continue
+            return UploadResult(False, int(exc.code), _response_message(exc.code, response_body))
+        except (urllib_error.URLError, TimeoutError, OSError) as exc:
+            if attempt + 1 < max_attempts:
+                _retry_wait(attempt)
+                continue
+            return UploadResult(False, None, f"网络连接失败：{getattr(exc, 'reason', exc)}")
+    raise RuntimeError("星石截图上传重试循环异常结束")
+
+
+def _response_message(status_code: int, response_body: str) -> str:
+    try:
+        payload = json.loads(response_body)
+        message = payload.get("message") or (payload.get("error") or {}).get("message")
+        if isinstance(message, str) and message.strip():
+            return f"HTTP {status_code}：{message.strip()}"
+    except (json.JSONDecodeError, AttributeError):
+        pass
+    return f"HTTP {status_code}"

--- a/agent/tests/test_inventory_reporting.py
+++ b/agent/tests/test_inventory_reporting.py
@@ -104,6 +104,7 @@ class InventoryReportingTests(unittest.TestCase):
             _Context({"mode": "仅保存到本地"})
         )
         self.assertEqual(local.token, "")
+        self.assertEqual(local.base_url, inventory_reporting.DEFAULT_BASE_URL)
         self.assertIsNone(local.report_filename)
 
     def test_custom_report_filename_builds_account_specific_txt_path(self):

--- a/agent/tests/test_star_backpack_capture_orchestration.py
+++ b/agent/tests/test_star_backpack_capture_orchestration.py
@@ -1,0 +1,226 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import numpy as np
+
+
+AGENT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(AGENT_ROOT))
+
+_MODULE_PATH = AGENT_ROOT / "custom" / "action" / "star_backpack_capture_orchestration.py"
+_SPEC = importlib.util.spec_from_file_location(
+    "star_backpack_capture_orchestration_test", _MODULE_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+
+StarBackpackCaptureOrchestration = _MODULE.StarBackpackCaptureOrchestration
+assemble_capture_batch = _MODULE.assemble_capture_batch
+parse_params = _MODULE.parse_star_backpack_capture_orchestration_params
+
+
+def _feedback():
+    return {
+        "max_micro_attempts": 2,
+        "local_search_radius_px": 20,
+        "diagnostic_safe_shift_px": [300, 600],
+        "diagnostic_expected_shift_px": [250, 700],
+        "diagnostic_physical_shift_px": [30, 700],
+        "diagnostic_target_shift_px": [610, 630],
+        "diagnostic_normal_safe_shift_px": [560, 650],
+        "diagnostic_row_pitch_px": 166.5,
+        "diagnostic_micro_trigger_shift_px": 300,
+        "diagnostic_min_confidence": 0.2,
+        "diagnostic_min_local_overlap_score": 0.6,
+        "diagnostic_no_move_similarity": 0.97,
+        "diagnostic_no_move_shift_px": 20,
+    }
+
+
+def _params(directory):
+    return {
+        "mode": "continuous_capture",
+        "game_version": "如鸢",
+        "debug_dir": directory,
+        "support_tab_task": "星石背包-点击辅星",
+        "experience_tab_task": "星石背包-点击经验星曜",
+        "tab_settle_ms": 0,
+        "compare_roi": [0, 0, 8, 8],
+        "swipe": {"start": [1, 2], "end": [3, 4], "duration_ms": 1},
+        "settle_ms": 0,
+        "max_transitions": 2,
+        "feedback": _feedback(),
+    }
+
+
+class _Controller:
+    def __init__(self, events):
+        self.events = events
+
+    def post_screencap(self):
+        self.events.append("screencap")
+        return self
+
+    def wait(self):
+        return self
+
+    def get(self):
+        return np.zeros((8, 8, 3), dtype=np.uint8)
+
+
+class _Context:
+    def __init__(self):
+        self.events = []
+        self.tasker = SimpleNamespace(controller=_Controller(self.events))
+
+    def run_task(self, name):
+        self.events.append(f"task:{name}")
+        return SimpleNamespace(status=SimpleNamespace(succeeded=True))
+
+
+class _FakeProbe:
+    def _capture(self, context):
+        return context.tasker.controller.post_screencap().wait().get()
+
+    def _run_continuous_capture(self, _context, _params, run_dir, _initial):
+        section = run_dir.name
+        return {
+            "success": True,
+            "stop_reason": "bottom_no_move",
+            "retained_images": ["capture-00.png", "capture-01.png"],
+            "retained_image_count": 2,
+            "adjacent_relations": (
+                [{"previous_image": "capture-00.png", "current_image": "capture-01.png", "relation": "overlap"}]
+                if section == "main"
+                else []
+            ),
+        }
+
+
+class StarBackpackCaptureOrchestrationTests(unittest.TestCase):
+    def test_happy_path_switches_each_tab_once_and_captures_experience_once(self):
+        with tempfile.TemporaryDirectory() as directory:
+            context = _Context()
+            with mock.patch.object(_MODULE, "StarBackpackCaptureProbe", _FakeProbe), mock.patch.object(_MODULE, "upload_full_capture_batch", return_value=None) as upload:
+                result = StarBackpackCaptureOrchestration().run(
+                    context, SimpleNamespace(custom_action_param=_params(directory))
+                )
+            run_dir = next(Path(directory).iterdir())
+            batch = json.loads((run_dir / "capture-batch.json").read_text(encoding="utf-8"))
+
+        self.assertTrue(getattr(result, "success", False))
+        upload.assert_called_once_with(context, run_dir)
+        self.assertEqual(
+            context.events,
+            [
+                "screencap",
+                "task:星石背包-点击辅星",
+                "screencap",
+                "task:星石背包-点击经验星曜",
+                "screencap",
+            ],
+        )
+        self.assertEqual(list(batch["sections"]), ["main", "support", "experience"])
+        self.assertEqual(batch["sections"]["experience"]["stopReason"], "single_capture")
+        self.assertEqual(len(batch["sections"]["experience"]["images"]), 1)
+        self.assertEqual(batch["sections"]["experience"]["adjacentRelations"], [])
+        self.assertEqual(
+            [
+                image["sourceOrder"]
+                for section in batch["sections"].values()
+                for image in section["images"]
+            ],
+            [1, 2, 3, 4, 5],
+        )
+
+    def test_batch_ids_and_relations_remain_section_local(self):
+        scroll_session = {
+            "success": True,
+            "retained_images": ["capture-00.png", "capture-01.png", "capture-02.png"],
+            "adjacent_relations": [
+                {"previous_image": "capture-00.png", "current_image": "capture-01.png", "relation": "overlap"}
+            ],
+        }
+        support_session = {
+            "success": True,
+            "retained_images": ["capture-00.png", "capture-01.png"],
+            "adjacent_relations": [
+                {"previous_image": "capture-00.png", "current_image": "capture-01.png", "relation": "overlap"}
+            ],
+        }
+        experience_session = {
+            "success": True,
+            "retained_images": ["capture-00.png"],
+            "adjacent_relations": [],
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            batch = assemble_capture_batch(
+                Path(directory), "如鸢", scroll_session, support_session, experience_session
+            )
+
+        orders = [
+            image["sourceOrder"]
+            for section in batch["sections"].values()
+            for image in section["images"]
+        ]
+        self.assertEqual(orders, [1, 2, 3, 4, 5, 6])
+        main_ids = {image["sourceImageId"] for image in batch["sections"]["main"]["images"]}
+        support_ids = {image["sourceImageId"] for image in batch["sections"]["support"]["images"]}
+        self.assertTrue(all(set(relation.values()) - {"overlap"} <= main_ids for relation in batch["sections"]["main"]["adjacentRelations"]))
+        self.assertTrue(all(set(relation.values()) - {"overlap"} <= support_ids for relation in batch["sections"]["support"]["adjacentRelations"]))
+        self.assertEqual(batch["sections"]["experience"]["adjacentRelations"], [])
+
+    def test_pipeline_uses_click_nodes_without_ocr_and_exposes_full_batch_transport(self):
+        pipeline_path = (
+            AGENT_ROOT.parent
+            / "assets"
+            / "resource"
+            / "base"
+            / "pipeline"
+            / "star_backpack_capture_orchestration.json"
+        )
+        pipeline = json.loads(pipeline_path.read_text(encoding="utf-8"))
+        params = pipeline["星石背包-正式三段采集"]["action"]["param"][
+            "custom_action_param"
+        ]
+        interface = json.loads(
+            (AGENT_ROOT.parent / "assets" / "interface.json").read_text(encoding="utf-8")
+        )
+        self.assertFalse(
+            any(task["name"].startswith("开发调试｜星石") for task in interface["task"])
+        )
+        toolbox_mode = interface["option"]["百宝箱-模式"]
+        star_capture_case = next(
+            case for case in toolbox_mode["cases"] if case["name"] == "星石背包自动采集"
+        )
+        self.assertEqual(star_capture_case["option"], ["同步星石至YuanHub"])
+        self.assertEqual(
+            star_capture_case["pipeline_override"]["百宝箱启动"]["next"],
+            ["星石背包-正式三段采集"],
+        )
+        self.assertEqual(params["support_tab_task"], "星石背包-点击辅星")
+        self.assertEqual(params["experience_tab_task"], "星石背包-点击经验星曜")
+        for task_name in (params["support_tab_task"], params["experience_tab_task"]):
+            node = pipeline[task_name]
+            self.assertEqual(node["recognition"]["type"], "DirectHit")
+            self.assertEqual(node["action"]["type"], "Click")
+        self.assertEqual(
+            pipeline["星石背包-点击辅星"]["recognition"]["param"]["roi"],
+            [320, 215, 80, 40],
+        )
+        self.assertEqual(
+            pipeline["星石背包-点击经验星曜"]["recognition"]["param"]["roi"],
+            [500, 215, 120, 40],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent/tests/test_star_backpack_capture_probe.py
+++ b/agent/tests/test_star_backpack_capture_probe.py
@@ -1,0 +1,2056 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from unittest import mock
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import cv2
+
+
+AGENT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(AGENT_ROOT))
+
+_MODULE_PATH = AGENT_ROOT / "custom" / "action" / "star_backpack_capture_probe.py"
+_SPEC = importlib.util.spec_from_file_location("star_backpack_capture_probe_test", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+compute_visual_overlap = _MODULE.compute_visual_overlap
+estimate_vertical_motion = _MODULE.estimate_vertical_motion
+evaluate_feedback_candidate = _MODULE.evaluate_feedback_candidate
+feedback_metrics_contract = _MODULE._feedback_metrics_contract
+is_capture_safe_progress = _MODULE._is_capture_safe_progress
+evaluate_semantic_row_overlap = _MODULE.evaluate_semantic_row_overlap
+estimate_row_lattice = _MODULE._estimate_row_lattice
+local_overlap_confirmation = _MODULE._local_overlap_confirmation
+apply_direct_overlap_anchors = _MODULE._apply_direct_overlap_anchors
+find_direct_normal_band_candidate = _MODULE._find_direct_normal_band_candidate
+merge_direct_normal_candidate = _MODULE._merge_direct_normal_candidate
+MotionHypothesis = _MODULE._MotionHypothesis
+MotionEstimate = _MODULE.MotionEstimate
+select_motion_hypothesis = _MODULE._select_motion_hypothesis
+parse_capture_probe_params = _MODULE.parse_capture_probe_params
+StarBackpackCaptureProbe = _MODULE.StarBackpackCaptureProbe
+
+
+class _FakeScreencapTask:
+    def __init__(self, image):
+        self.images = [image] if isinstance(image, np.ndarray) else list(image)
+        self.screencap_calls = 0
+        self.swipes = []
+
+    def post_screencap(self):
+        return self
+
+    def wait(self):
+        return self
+
+    def get(self):
+        image = self.images[min(self.screencap_calls, len(self.images) - 1)]
+        self.screencap_calls += 1
+        return image
+
+    def post_swipe(self, *gesture):
+        self.swipes.append(gesture)
+        return self
+
+
+class _FakeCaptureContext:
+    def __init__(self, image):
+        self.tasker = SimpleNamespace(controller=_FakeScreencapTask(image))
+
+
+def _complex_scene(height=360, width=240, seed=1):
+    rng = np.random.default_rng(seed)
+    image = rng.integers(0, 70, size=(height, width, 3), dtype=np.uint8)
+    for index, y in enumerate(range(25, height, 43)):
+        color = tuple(int(value) for value in rng.integers(90, 255, size=3))
+        cv2.circle(image, (35 + (index % 4) * 55, y), 14, color, 2)
+        cv2.line(image, (5, y + 10), (width - 6, y - 7), color, 1)
+        cv2.putText(
+            image,
+            f"{seed}-{index}",
+            (100, min(height - 6, y + 7)),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.36,
+            color,
+            1,
+            cv2.LINE_AA,
+        )
+    return image
+
+
+def _shift_up(before, shift, seed=99):
+    rng = np.random.default_rng(seed)
+    tail = rng.integers(
+        0, 256, size=(shift, before.shape[1], before.shape[2]), dtype=np.uint8
+    )
+    return np.vstack([before[shift:, :, :], tail])
+
+
+def _periodic_scene_with_unique_tail(height=900, width=300, period=68, seed=701):
+    tile = _complex_scene(height=period, width=width, seed=seed)
+    image = np.tile(tile, (height // period + 1, 1, 1))[:height].copy()
+    for index, y in enumerate((570, 635, 700, 765, 830)):
+        color = (20 + index * 35, 250 - index * 25, 80 + index * 20)
+        cv2.rectangle(image, (22 + index * 32, y), (65 + index * 32, y + 32), color, -1)
+        cv2.putText(
+            image,
+            f"UNIQUE-{index}",
+            (105, y + 25),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.62,
+            color,
+            2,
+            cv2.LINE_AA,
+        )
+    return image
+
+
+def _feedback_config(safe_min=100, safe_max=230):
+    return {
+        "max_micro_attempts": 2,
+        "local_search_radius_px": 20,
+        "diagnostic_safe_shift_px": (safe_min, safe_max),
+        "diagnostic_expected_shift_px": (25, 700),
+        "diagnostic_physical_shift_px": (20, 700),
+        "diagnostic_target_shift_px": (150, 200),
+        "diagnostic_normal_safe_shift_px": (safe_min, safe_max),
+        "diagnostic_row_pitch_px": 166.5,
+        "diagnostic_micro_trigger_shift_px": 100,
+        "diagnostic_min_confidence": 0.20,
+        "diagnostic_min_local_overlap_score": 0.60,
+        "diagnostic_no_move_similarity": 0.97,
+        "diagnostic_no_move_shift_px": 20,
+    }
+
+
+def _b1d_feedback_config():
+    return {
+        "max_micro_attempts": 2,
+        "local_search_radius_px": 20,
+        "diagnostic_safe_shift_px": (300, 600),
+        "diagnostic_expected_shift_px": (250, 700),
+        "diagnostic_physical_shift_px": (30, 700),
+        "diagnostic_target_shift_px": (610, 630),
+        "diagnostic_normal_safe_shift_px": (560, 650),
+        "diagnostic_row_pitch_px": 166.5,
+        "diagnostic_micro_trigger_shift_px": 300,
+        "diagnostic_min_confidence": 0.20,
+        "diagnostic_min_local_overlap_score": 0.60,
+        "diagnostic_no_move_similarity": 0.97,
+        "diagnostic_no_move_shift_px": 20,
+    }
+
+
+def _continuous_capture_params(directory, max_transitions=5, height=760):
+    return {
+        "mode": "continuous_capture",
+        "debug_dir": directory,
+        "compare_roi": [0, 0, 240, height],
+        "swipe": {
+            "start": [360, 930],
+            "end": [360, 540],
+            "duration_ms": 700,
+        },
+        "settle_ms": 0,
+        "max_transitions": max_transitions,
+        "feedback": _b1d_feedback_config(),
+    }
+
+
+def _b1_transition_evaluation(
+    state,
+    accepted,
+    *,
+    actual_shift_px=None,
+    motion_reliability="orb_confidence",
+):
+    pair_required = state in {"definitely_full_row", "ambiguous"}
+    return {
+        "accepted": accepted,
+        "relation": "overlap" if accepted and pair_required else None,
+        "ocr_overlap_pair_required": pair_required,
+        "semantic_overlap_state": state,
+        "motion_reliability": {"mode": motion_reliability},
+        "actual_shift_px": (
+            actual_shift_px
+            if actual_shift_px is not None
+            else (620.0 if accepted else 0.0)
+        ),
+        "physical_overlap_px": 140.0 if accepted else 760.0,
+    }
+
+
+class StarBackpackCaptureProbeParamsTests(unittest.TestCase):
+    def test_capture_only_uses_safe_defaults(self):
+        self.assertEqual(
+            parse_capture_probe_params({}),
+            {"mode": "capture_only", "debug_dir": "debug/star-backpack-probe"},
+        )
+
+    def test_pair_probe_requires_explicit_roi(self):
+        with self.assertRaisesRegex(ValueError, "compare_roi"):
+            parse_capture_probe_params(
+                {
+                    "mode": "pair_probe",
+                    "swipe": {
+                        "start": [1, 2],
+                        "end": [3, 4],
+                        "duration_ms": 400,
+                    },
+                }
+            )
+
+    def test_pair_probe_requires_explicit_swipe(self):
+        with self.assertRaisesRegex(ValueError, "swipe"):
+            parse_capture_probe_params(
+                {"mode": "pair_probe", "compare_roi": [0, 0, 40, 40]}
+            )
+
+    def test_capture_only_saves_raw_png_and_metadata_without_swiping(self):
+        image = np.zeros((13, 17, 3), dtype=np.uint8)
+        with tempfile.TemporaryDirectory() as directory:
+            result = StarBackpackCaptureProbe().run(
+                _FakeCaptureContext(image),
+                SimpleNamespace(
+                    custom_action_param={
+                        "mode": "capture_only",
+                        "debug_dir": directory,
+                    }
+                ),
+            )
+            self.assertTrue(getattr(result, "success", False))
+            run_dir = next(Path(directory).iterdir())
+            metadata = json.loads((run_dir / "metadata.json").read_text(encoding="utf-8"))
+            self.assertTrue((run_dir / "capture.png").is_file())
+            self.assertEqual(
+                {key: metadata[key] for key in ("mode", "width", "height", "channels", "dtype", "file")},
+                {
+                    "mode": "capture_only",
+                    "width": 17,
+                    "height": 13,
+                    "channels": 3,
+                    "dtype": "uint8",
+                    "file": "capture.png",
+                },
+            )
+
+    def test_continuous_capture_requires_a_bounded_transition_count(self):
+        with self.assertRaisesRegex(ValueError, "max_transitions"):
+            parse_capture_probe_params(
+                {
+                    "mode": "continuous_capture",
+                    "compare_roi": [0, 0, 240, 760],
+                    "swipe": {
+                        "start": [360, 930],
+                        "end": [360, 540],
+                        "duration_ms": 700,
+                    },
+                    "settle_ms": 2500,
+                    "feedback": _b1d_feedback_config(),
+                }
+            )
+
+class StarBackpackCaptureProbeVisualTests(unittest.TestCase):
+    def test_identical_images_have_high_same_position_score(self):
+        image = np.random.default_rng(10).integers(
+            0, 256, size=(100, 60, 3), dtype=np.uint8
+        )
+        metrics = compute_visual_overlap(image, image.copy(), 0.20, 0.90)
+        self.assertGreater(metrics["same_position_score"], 0.99)
+        self.assertEqual(metrics["classification"], "diagnostic_only")
+
+    def test_known_vertical_overlap_is_found(self):
+        rng = np.random.default_rng(20)
+        before = rng.integers(0, 256, size=(100, 50, 3), dtype=np.uint8)
+        shift = 30
+        after = np.vstack(
+            [
+                before[shift:, :, :],
+                rng.integers(0, 256, size=(shift, 50, 3), dtype=np.uint8),
+            ]
+        )
+        metrics = compute_visual_overlap(before, after, 0.20, 0.90)
+        self.assertEqual(metrics["best_overlap_px"], 100 - shift)
+        self.assertGreater(metrics["best_overlap_score"], 0.99)
+        self.assertEqual(metrics["best_shift_px"], shift)
+
+    def test_unrelated_images_do_not_report_high_confidence_overlap(self):
+        first = np.random.default_rng(30).integers(
+            0, 256, size=(100, 60, 3), dtype=np.uint8
+        )
+        second = np.random.default_rng(40).integers(
+            0, 256, size=(100, 60, 3), dtype=np.uint8
+        )
+        metrics = compute_visual_overlap(first, second, 0.20, 0.90)
+        self.assertLess(metrics["best_overlap_score"], 0.30)
+
+
+class StarBackpackCaptureProbeFeedbackTests(unittest.TestCase):
+    def test_semantic_overlap_requires_complete_row_envelope_not_physical_height(self):
+        image = np.zeros((760, 240, 3), dtype=np.uint8)
+        result = evaluate_semantic_row_overlap(
+            image,
+            image.copy(),
+            620,
+            166.5,
+            prev_row_centers=[690.0],
+            candidate_row_centers=[70.0],
+        )
+        self.assertTrue(result["visual_overlap"])
+        self.assertEqual(result["physical_overlap_px"], 140)
+        self.assertEqual(result["semantic_overlap_state"], "definitely_no_full_row")
+        self.assertFalse(result["ocr_overlap_pair_required"])
+
+    def test_semantic_overlap_marks_complete_row_in_both_shared_regions(self):
+        image = np.zeros((760, 240, 3), dtype=np.uint8)
+        result = evaluate_semantic_row_overlap(
+            image,
+            image.copy(),
+            560,
+            166.5,
+            prev_row_centers=[650.0],
+            candidate_row_centers=[90.0],
+        )
+        self.assertTrue(result["visual_overlap"])
+        self.assertEqual(result["semantic_overlap_state"], "definitely_full_row")
+        self.assertTrue(result["ocr_overlap_pair_required"])
+        self.assertTrue(result["full_row_candidates"])
+
+    def test_semantic_overlap_preserves_ambiguous_boundary_conservatively(self):
+        image = np.zeros((760, 240, 3), dtype=np.uint8)
+        result = evaluate_semantic_row_overlap(
+            image,
+            image.copy(),
+            560,
+            166.5,
+            prev_row_centers=[625.0],
+            candidate_row_centers=[65.0],
+        )
+        self.assertEqual(result["semantic_overlap_state"], "ambiguous")
+        self.assertTrue(result["ocr_overlap_pair_required"])
+        self.assertEqual(result["reason"], "envelope_near_shared_region_boundary")
+
+    def test_semantic_overlap_rejects_rows_that_cross_the_shared_boundary(self):
+        image = np.zeros((760, 240, 3), dtype=np.uint8)
+        boundary_center = 560.0 + 1.06 * (166.5 * 0.34)
+        for clearance in (-9.0, -1.0):
+            with self.subTest(clearance=clearance):
+                result = evaluate_semantic_row_overlap(
+                    image,
+                    image.copy(),
+                    560,
+                    166.5,
+                    prev_row_centers=[boundary_center + clearance],
+                    candidate_row_centers=[boundary_center - 560.0 + clearance],
+                )
+                self.assertEqual(result["semantic_overlap_state"], "definitely_no_full_row")
+                self.assertFalse(result["ocr_overlap_pair_required"])
+
+    def test_semantic_overlap_keeps_nonnegative_boundary_clearance_ambiguous(self):
+        image = np.zeros((760, 240, 3), dtype=np.uint8)
+        boundary_center = 560.0 + 1.06 * (166.5 * 0.34)
+        for clearance in range(0, 10):
+            with self.subTest(clearance=clearance):
+                result = evaluate_semantic_row_overlap(
+                    image,
+                    image.copy(),
+                    560,
+                    166.5,
+                    prev_row_centers=[boundary_center + clearance],
+                    candidate_row_centers=[boundary_center - 560.0 + clearance],
+                )
+                self.assertEqual(result["semantic_overlap_state"], "ambiguous")
+                self.assertTrue(result["ocr_overlap_pair_required"])
+
+    def test_semantic_overlap_marks_safety_margin_and_beyond_as_full(self):
+        image = np.zeros((760, 240, 3), dtype=np.uint8)
+        boundary_center = 560.0 + 1.06 * (166.5 * 0.34)
+        for clearance in (10.0, 30.0):
+            with self.subTest(clearance=clearance):
+                result = evaluate_semantic_row_overlap(
+                    image,
+                    image.copy(),
+                    560,
+                    166.5,
+                    prev_row_centers=[boundary_center + clearance],
+                    candidate_row_centers=[boundary_center - 560.0 + clearance],
+                )
+                self.assertEqual(result["semantic_overlap_state"], "definitely_full_row")
+                self.assertTrue(result["ocr_overlap_pair_required"])
+
+    def test_same_physical_overlap_can_have_different_semantic_row_phase(self):
+        image = np.zeros((760, 240, 3), dtype=np.uint8)
+        complete = evaluate_semantic_row_overlap(
+            image, image.copy(), 560, 166.5,
+            prev_row_centers=[650.0], candidate_row_centers=[90.0],
+        )
+        partial = evaluate_semantic_row_overlap(
+            image, image.copy(), 560, 166.5,
+            prev_row_centers=[700.0], candidate_row_centers=[140.0],
+        )
+        self.assertEqual(complete["physical_overlap_px"], partial["physical_overlap_px"])
+        self.assertTrue(complete["ocr_overlap_pair_required"])
+        self.assertFalse(partial["ocr_overlap_pair_required"])
+
+    def test_row_lattice_estimates_current_frame_phase_from_visual_edges(self):
+        image = np.zeros((760, 240, 3), dtype=np.uint8)
+        pitch = 166.5
+        radius = pitch * 0.34
+        expected_phase = 80.0
+        for center in np.arange(expected_phase, image.shape[0], pitch):
+            for offset in (-radius, radius, -radius * 0.77, radius * 1.39):
+                y = int(round(center + offset))
+                if 0 <= y < image.shape[0]:
+                    cv2.line(image, (0, y), (image.shape[1] - 1, y), (255, 255, 255), 2)
+        lattice = estimate_row_lattice(image, pitch)
+        self.assertAlmostEqual(lattice["phase_px"], expected_phase, delta=3)
+        self.assertGreaterEqual(len(lattice["row_centers"]), 4)
+
+    def test_orb_ransac_recovers_known_vertical_motion(self):
+        before = _complex_scene(seed=101)
+        estimate = estimate_vertical_motion(before, _shift_up(before, 118, seed=102))
+        self.assertAlmostEqual(estimate.shift_y, 118, delta=4)
+        self.assertGreaterEqual(estimate.inlier_count, 8)
+        self.assertGreater(estimate.confidence, 0.20)
+
+    def test_orb_estimate_does_not_jump_to_repeated_background_period(self):
+        height, width, period, shift = 360, 240, 45, 97
+        tile = _complex_scene(height=period, width=width, seed=201)
+        before = np.tile(tile, (height // period + 1, 1, 1))[:height].copy()
+        cv2.putText(before, "UNIQUE-A", (18, 118), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (255, 255, 255), 2)
+        cv2.rectangle(before, (160, 210), (215, 260), (17, 243, 91), -1)
+        after = _shift_up(before, shift, seed=202)
+        estimate = estimate_vertical_motion(before, after)
+        self.assertAlmostEqual(estimate.shift_y, shift, delta=5)
+        self.assertGreater(estimate.confidence, 0.20)
+
+    def test_hypothesis_clustering_selects_true_large_positive_motion(self):
+        before = _periodic_scene_with_unique_tail()
+        actual_shift = 560
+        after = _shift_up(before, actual_shift, seed=702)
+        estimate = estimate_vertical_motion(before, after, (250, 700))
+        self.assertAlmostEqual(estimate.shift_y, actual_shift, delta=7)
+        self.assertIsNotNone(estimate.selected_hypothesis)
+        self.assertGreater(len(estimate.motion_hypotheses), 1)
+        self.assertGreater(estimate.selected_hypothesis["match_count"], 4)
+
+    def test_reverse_motion_alias_is_rejected_before_hypothesis_selection(self):
+        before = np.random.default_rng(711).integers(
+            0, 256, size=(480, 240, 3), dtype=np.uint8
+        )
+        downward = np.vstack(
+            [
+                np.random.default_rng(712).integers(
+                    0, 256, size=(100, 240, 3), dtype=np.uint8
+                ),
+                before[:-100, :, :],
+            ]
+        )
+        estimate = estimate_vertical_motion(before, downward, (25, 400))
+        self.assertLessEqual(estimate.confidence, 0.01)
+        self.assertIsNone(estimate.selected_hypothesis)
+        self.assertGreater(estimate.direction_rejected_match_count, 0)
+
+    def test_out_of_range_local_confirmation_is_explicitly_invalid(self):
+        image = _complex_scene(seed=721)
+        score, shift, valid = local_overlap_confirmation(image, image, -70, 20)
+        self.assertIsNone(score)
+        self.assertIsNone(shift)
+        self.assertFalse(valid)
+
+    def test_identical_image_has_dual_no_move_evidence(self):
+        image = _complex_scene(seed=301)
+        result = evaluate_feedback_candidate(image, image.copy(), _feedback_config())
+        self.assertGreater(result["same_position_score"], 0.99)
+        self.assertLess(abs(result["shift_estimate"]["shift_y"]), 3)
+        self.assertEqual(result["reason"], "bottom_no_move")
+        self.assertEqual(result["semantic_overlap_state"], "not_applicable_no_move")
+        self.assertFalse(result["ocr_overlap_pair_required"])
+
+    def test_unrelated_image_is_rejected(self):
+        first = np.random.default_rng(401).integers(
+            0, 256, size=(360, 240, 3), dtype=np.uint8
+        )
+        second = np.random.default_rng(402).integers(
+            0, 256, size=(360, 240, 3), dtype=np.uint8
+        )
+        result = evaluate_feedback_candidate(
+            first, second, _feedback_config()
+        )
+        self.assertFalse(result["accepted"])
+        self.assertLess(result["shift_estimate"]["confidence"], 0.35)
+        self.assertEqual(result["reason"], "unsafe_gap_risk")
+        self.assertEqual(
+            result["semantic_overlap_state"],
+            "not_applicable_unreliable_motion",
+        )
+        self.assertFalse(result["ocr_overlap_pair_required"])
+        self.assertEqual(result["full_row_candidates"], [])
+        self.assertEqual(
+            result["semantic_overlap_reason"],
+            "unreliable_motion_not_an_adjacent_pair",
+        )
+        self.assertIsNone(result["relation"])
+
+    def test_unrelated_full_probe_has_no_image_pair(self):
+        prev = np.random.default_rng(411).integers(
+            0, 256, size=(360, 240, 3), dtype=np.uint8
+        )
+        unrelated = np.random.default_rng(412).integers(
+            0, 256, size=(360, 240, 3), dtype=np.uint8
+        )
+        params = {
+            "mode": "feedback_probe",
+            "debug_dir": "unused",
+            "compare_roi": [0, 0, 240, 360],
+            "coarse_swipe": {
+                "start": [360, 930], "end": [360, 560], "duration_ms": 700
+            },
+            "micro_swipe": {
+                "start": [360, 930], "end": [360, 800], "duration_ms": 500
+            },
+            "settle_ms": 0,
+            "feedback": _feedback_config(),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            params["debug_dir"] = directory
+            result = StarBackpackCaptureProbe().run(
+                _FakeCaptureContext([prev, unrelated]),
+                SimpleNamespace(custom_action_param=params),
+            )
+            self.assertTrue(getattr(result, "success", False))
+            run_dir = next(Path(directory).iterdir())
+            metrics = json.loads(
+                (run_dir / "feedback-metrics.json").read_text(encoding="utf-8")
+            )
+        self.assertFalse(metrics["accepted"])
+        self.assertEqual(
+            metrics["semantic_overlap_state"],
+            "not_applicable_unreliable_motion",
+        )
+        self.assertFalse(metrics["ocr_overlap_pair_required"])
+        self.assertIsNone(metrics["relation"])
+        self.assertIsNone(metrics["image_pair"])
+
+    def test_terminal_confirmation_accepts_temporary_candidate_at_bottom(self):
+        prev = _complex_scene(seed=501)
+        first_candidate = _shift_up(prev, 55, seed=502)
+        params = {
+            "mode": "feedback_probe",
+            "debug_dir": "unused",
+            "compare_roi": [0, 0, 240, 360],
+            "coarse_swipe": {
+                "start": [360, 930], "end": [360, 560], "duration_ms": 700
+            },
+            "micro_swipe": {
+                "start": [360, 930], "end": [360, 800], "duration_ms": 500
+            },
+            "settle_ms": 0,
+            "feedback": _feedback_config(),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            params["debug_dir"] = directory
+            context = _FakeCaptureContext([prev, first_candidate, first_candidate])
+            result = StarBackpackCaptureProbe().run(
+                context, SimpleNamespace(custom_action_param=params)
+            )
+            self.assertTrue(getattr(result, "success", False))
+            run_dir = next(Path(directory).iterdir())
+            metrics = json.loads(
+                (run_dir / "feedback-metrics.json").read_text(encoding="utf-8")
+            )
+            self.assertTrue(metrics["accepted"])
+            self.assertEqual(metrics["relation"], "overlap")
+            self.assertTrue(metrics["ocr_overlap_pair_required"])
+            self.assertIsNotNone(metrics["image_pair"])
+            self.assertTrue(metrics["section_complete"])
+            self.assertEqual(
+                set(metrics),
+                {
+                    "accepted",
+                    "relation",
+                    "ocr_overlap_pair_required",
+                    "semantic_overlap_state",
+                    "section_complete",
+                    "image_pair",
+                    "diagnostics",
+                },
+            )
+            self.assertEqual(
+                set(metrics["diagnostics"]),
+                {"actual_shift_px", "motion_reliability", "physical_overlap_px"},
+            )
+            self.assertNotIn("relation", metrics["image_pair"])
+            self.assertEqual(len(context.tasker.controller.swipes), 2)
+            self.assertTrue((run_dir / "prev.png").is_file())
+            self.assertTrue((run_dir / "candidate.png").is_file())
+
+    def test_feedback_accepts_safe_candidate_and_rejects_unsafe_overshoot(self):
+        prev = _complex_scene(seed=601)
+        params = {
+            "mode": "feedback_probe",
+            "debug_dir": "unused",
+            "compare_roi": [0, 0, 240, 360],
+            "coarse_swipe": {
+                "start": [360, 930], "end": [360, 560], "duration_ms": 700
+            },
+            "micro_swipe": {
+                "start": [360, 930], "end": [360, 800], "duration_ms": 500
+            },
+            "settle_ms": 0,
+            "feedback": _feedback_config(),
+        }
+        for candidate, expected_accepted, expected_reason in (
+            (_shift_up(prev, 160, seed=602), True, "diagnostic_only"),
+            (_shift_up(prev, 275, seed=603), False, "unsafe_gap_risk"),
+        ):
+            with self.subTest(expected_accepted=expected_accepted):
+                with tempfile.TemporaryDirectory() as directory:
+                    params["debug_dir"] = directory
+                    context = _FakeCaptureContext([prev, candidate])
+                    result = StarBackpackCaptureProbe().run(
+                        context, SimpleNamespace(custom_action_param=params)
+                    )
+                    self.assertTrue(getattr(result, "success", False))
+                    run_dir = next(Path(directory).iterdir())
+                    metrics = json.loads(
+                        (run_dir / "feedback-metrics.json").read_text(encoding="utf-8")
+                    )
+                    self.assertEqual(metrics["accepted"], expected_accepted)
+                    self.assertNotIn("reason", metrics)
+                    self.assertEqual(
+                        evaluate_feedback_candidate(prev, candidate, params["feedback"])["reason"],
+                        expected_reason,
+                    )
+                    self.assertEqual(len(context.tasker.controller.swipes), 1)
+
+    def test_correct_large_shift_still_rejects_outside_safe_range(self):
+        before = _periodic_scene_with_unique_tail()
+        candidate = _shift_up(before, 560, seed=731)
+        feedback = _feedback_config(safe_min=140, safe_max=520)
+        feedback["diagnostic_expected_shift_px"] = (250, 700)
+        result = evaluate_feedback_candidate(before, candidate, feedback)
+        self.assertGreater(result["shift_estimate"]["shift_y"], 540)
+        self.assertFalse(result["accepted"])
+        self.assertEqual(result["reason"], "unsafe_gap_risk")
+
+    def test_normal_motion_band_selects_each_locked_real_distribution(self):
+        before = np.random.default_rng(801).integers(
+            0, 256, size=(760, 260, 3), dtype=np.uint8
+        )
+        for shift, seed in ((596, 802), (622, 803), (640, 804)):
+            with self.subTest(shift=shift):
+                estimate = estimate_vertical_motion(
+                    before,
+                    _shift_up(before, shift, seed=seed),
+                    (250, 700),
+                    (30, 700),
+                )
+                self.assertAlmostEqual(estimate.shift_y, shift, delta=6)
+                self.assertGreater(estimate.confidence, 0.20)
+                self.assertEqual(
+                    estimate.selected_hypothesis["selection_mode"],
+                    "normal_motion_full_overlap",
+                )
+                self.assertFalse(estimate.selected_hypothesis["fallback_used"])
+
+    def test_near_bottom_strong_230_hypothesis_beats_weak_expected_396_hypothesis(self):
+        strong_near_bottom = MotionHypothesis(
+            matches=[object()] * 175,
+            shift_y=230.0,
+            median_abs_deviation=1.0,
+            x_coverage=0.80,
+            y_coverage=0.70,
+            mean_descriptor_distance=24.0,
+        )
+        weak_expected = MotionHypothesis(
+            matches=[object()] * 12,
+            shift_y=396.0,
+            median_abs_deviation=1.5,
+            x_coverage=0.35,
+            y_coverage=0.30,
+            mean_descriptor_distance=45.0,
+        )
+        selected, reason, hypotheses = select_motion_hypothesis(
+            [strong_near_bottom, weak_expected], (250, 700), (30, 700)
+        )
+        self.assertIs(selected, strong_near_bottom)
+        self.assertFalse(reason["inside_legacy_expected_range"])
+        self.assertEqual(reason["selection_mode"], "terminal_fallback")
+        self.assertTrue(reason["fallback_used"])
+        self.assertEqual(reason["match_count"], 175)
+        self.assertEqual(len(hypotheses), 2)
+
+    def test_normal_band_gate_beats_higher_count_low_periodic_alias(self):
+        low_alias = MotionHypothesis(
+            matches=[object()] * 220,
+            shift_y=289.0,
+            median_abs_deviation=0.5,
+            x_coverage=0.95,
+            y_coverage=0.80,
+            mean_descriptor_distance=12.0,
+            anchor_score=0.94,
+            anchor_height_px=120,
+            full_overlap_score=0.99,
+            full_overlap_height_px=459,
+            full_overlap_gray_score=0.99,
+            full_overlap_gradient_score=0.99,
+        )
+        true_normal = MotionHypothesis(
+            matches=[object()] * 12,
+            shift_y=622.0,
+            median_abs_deviation=1.0,
+            x_coverage=0.40,
+            y_coverage=0.35,
+            mean_descriptor_distance=45.0,
+            anchor_score=0.87,
+            anchor_height_px=120,
+            full_overlap_score=0.81,
+            full_overlap_height_px=126,
+            full_overlap_gray_score=0.81,
+            full_overlap_gradient_score=0.81,
+        )
+        selected, reason, _ = select_motion_hypothesis(
+            [low_alias, true_normal], (250, 700), (30, 700)
+        )
+        self.assertIs(selected, true_normal)
+        self.assertEqual(reason["selection_mode"], "normal_motion_full_overlap")
+        self.assertEqual(reason["normal_motion_candidate_count"], 1)
+        self.assertEqual(reason["selected_by"], "full_overlap_score")
+
+    def test_terminal_confirmed_selection_can_use_strong_short_orb_branch_only_after_bottom(self):
+        strong_terminal = MotionHypothesis(
+            matches=[object()] * 138,
+            shift_y=292.8,
+            median_abs_deviation=0.8,
+            x_coverage=0.85,
+            y_coverage=0.75,
+            mean_descriptor_distance=22.0,
+            anchor_score=0.87,
+            anchor_height_px=467,
+            full_overlap_score=0.95,
+            full_overlap_height_px=467,
+            full_overlap_gray_score=0.95,
+            full_overlap_gradient_score=0.95,
+        )
+        weak_normal_direct_alias = MotionHypothesis(
+            matches=[],
+            shift_y=626.0,
+            median_abs_deviation=0.0,
+            x_coverage=1.0,
+            y_coverage=1.0,
+            mean_descriptor_distance=None,
+            anchor_score=0.68,
+            anchor_height_px=134,
+            full_overlap_score=0.70,
+            full_overlap_height_px=134,
+            full_overlap_gray_score=0.70,
+            full_overlap_gradient_score=0.70,
+            proposal_source="direct_normal_band",
+        )
+        direct_search = {
+            "candidate_injected": True,
+            "best_shift_px": 626.0,
+            "best_score": 0.70,
+        }
+
+        ordinary, ordinary_reason, _ = select_motion_hypothesis(
+            [strong_terminal, weak_normal_direct_alias],
+            (250, 700),
+            (30, 700),
+            direct_search,
+        )
+        terminal, terminal_reason, _ = select_motion_hypothesis(
+            [strong_terminal, weak_normal_direct_alias],
+            (250, 700),
+            (30, 700),
+            direct_search,
+            terminal_confirmed=True,
+            terminal_max_shift_px=300.0,
+        )
+
+        self.assertIs(ordinary, weak_normal_direct_alias)
+        self.assertEqual(ordinary_reason["selection_mode"], "normal_motion_full_overlap")
+        self.assertIs(terminal, strong_terminal)
+        self.assertEqual(
+            terminal_reason["selection_mode"], "terminal_confirmed_short_motion"
+        )
+        self.assertEqual(terminal_reason["proposal_source"], "orb")
+
+    def test_terminal_recheck_requires_a_reanchored_semantic_pair(self):
+        estimate = MotionEstimate(
+            shift_y=292.8,
+            inlier_count=136,
+            match_count=138,
+            confidence=0.96,
+            selected_hypothesis={
+                "proposal_source": "orb",
+                "full_overlap_score": 0.95,
+                "anchor_score": 0.87,
+            },
+        )
+        initial_semantic = {
+            "semantic_overlap_state": "definitely_no_full_row",
+            "ocr_overlap_pair_required": False,
+            "candidate_row_centers": [96.0, 262.5],
+        }
+        reanchored_full = {
+            "semantic_overlap_state": "definitely_full_row",
+            "ocr_overlap_pair_required": True,
+        }
+        reanchored_none = {
+            "semantic_overlap_state": "definitely_no_full_row",
+            "ocr_overlap_pair_required": False,
+        }
+        previous = np.zeros((760, 240, 3), dtype=np.uint8)
+        candidate = np.zeros((760, 240, 3), dtype=np.uint8)
+
+        with mock.patch.object(
+            _MODULE, "estimate_vertical_motion", return_value=estimate
+        ) as motion, mock.patch.object(
+            _MODULE, "_local_overlap_confirmation", return_value=(0.91, 293, True)
+        ), mock.patch.object(
+            _MODULE,
+            "evaluate_semantic_row_overlap",
+            side_effect=[initial_semantic, reanchored_full],
+        ) as semantic:
+            self.assertTrue(
+                _MODULE._terminal_confirmed_overlap_pair_required(
+                    previous, candidate, _b1d_feedback_config()
+                )
+            )
+
+        self.assertTrue(motion.call_args.kwargs["terminal_confirmed"])
+        self.assertEqual(motion.call_args.kwargs["terminal_max_shift_px"], 300.0)
+        self.assertEqual(semantic.call_count, 2)
+        self.assertEqual(
+            semantic.call_args_list[1].kwargs["prev_row_centers"],
+            [388.8, 555.3],
+        )
+        with mock.patch.object(
+            _MODULE, "estimate_vertical_motion", return_value=estimate
+        ), mock.patch.object(
+            _MODULE, "_local_overlap_confirmation", return_value=(0.91, 293, True)
+        ), mock.patch.object(
+            _MODULE,
+            "evaluate_semantic_row_overlap",
+            side_effect=[initial_semantic, reanchored_none],
+        ):
+            self.assertFalse(
+                _MODULE._terminal_confirmed_overlap_pair_required(
+                    previous, candidate, _b1d_feedback_config()
+                )
+            )
+
+    def test_direct_normal_candidate_wins_with_zero_orb_feature_support(self):
+        low_alias = MotionHypothesis(
+            matches=[object()] * 220,
+            shift_y=318.0,
+            median_abs_deviation=0.5,
+            x_coverage=0.95,
+            y_coverage=0.80,
+            mean_descriptor_distance=12.0,
+            anchor_score=0.94,
+            anchor_height_px=120,
+            full_overlap_score=0.99,
+            full_overlap_height_px=430,
+            full_overlap_gray_score=0.99,
+            full_overlap_gradient_score=0.99,
+        )
+        direct_true = MotionHypothesis(
+            matches=[],
+            shift_y=640.0,
+            median_abs_deviation=0.0,
+            x_coverage=1.0,
+            y_coverage=1.0,
+            mean_descriptor_distance=None,
+            anchor_score=0.89,
+            anchor_height_px=108,
+            full_overlap_score=0.88,
+            full_overlap_height_px=108,
+            full_overlap_gray_score=0.87,
+            full_overlap_gradient_score=0.89,
+            proposal_source="direct_normal_band",
+        )
+        selected, reason, _ = select_motion_hypothesis(
+            [low_alias, direct_true], (250, 700), (30, 700)
+        )
+        self.assertIs(selected, direct_true)
+        self.assertEqual(reason["proposal_source"], "direct_normal_band")
+        self.assertEqual(reason["match_count"], 0)
+        self.assertEqual(reason["mean_descriptor_distance"], None)
+
+    def test_direct_search_supplements_orb_only_low_periodic_aliases(self):
+        before = np.random.default_rng(807).integers(
+            0, 256, size=(760, 240, 3), dtype=np.uint8
+        )
+        after = _shift_up(before, 622, seed=808)
+        aliases = [
+            MotionHypothesis(
+                matches=[object()] * count,
+                shift_y=float(shift),
+                median_abs_deviation=1.0,
+                x_coverage=0.80,
+                y_coverage=0.70,
+                mean_descriptor_distance=24.0,
+            )
+            for shift, count in ((151, 90), (318, 60), (484, 35))
+        ]
+        with mock.patch.object(
+            _MODULE, "_cluster_positive_vertical_matches", return_value=aliases
+        ):
+            estimate = estimate_vertical_motion(before, after, (250, 700), (30, 700))
+        self.assertAlmostEqual(estimate.shift_y, 622, delta=2)
+        self.assertEqual(
+            estimate.selected_hypothesis["proposal_source"], "direct_normal_band"
+        )
+        self.assertEqual(
+            estimate.selected_hypothesis["selection_mode"],
+            "normal_motion_full_overlap",
+        )
+        self.assertTrue(estimate.direct_normal_search["candidate_injected"])
+        self.assertLess(estimate.direct_normal_search["elapsed_ms"], 200)
+
+    def test_direct_candidate_dedupes_against_existing_orb_normal_branch(self):
+        before = np.random.default_rng(809).integers(
+            0, 256, size=(760, 240, 3), dtype=np.uint8
+        )
+        direct, diagnostics = find_direct_normal_band_candidate(
+            before, _shift_up(before, 622, seed=810)
+        )
+        self.assertIsNotNone(direct)
+        self.assertTrue(diagnostics["candidate_injected"])
+        orb_true = MotionHypothesis(
+            matches=[object()] * 12,
+            shift_y=622.0,
+            median_abs_deviation=1.0,
+            x_coverage=0.40,
+            y_coverage=0.35,
+            mean_descriptor_distance=45.0,
+        )
+        merged = merge_direct_normal_candidate([orb_true], direct)
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0].proposal_source, "merged")
+        self.assertEqual(len(merged[0].matches), 12)
+        self.assertAlmostEqual(merged[0].shift_y, direct.shift_y, delta=0.01)
+
+    def test_sparse_merged_direct_candidates_keep_normal_motion_eligibility(self):
+        cases = (
+            (625, 2, 125, 913),
+            (601, 1, 268, 914),
+        )
+        for shift, orb_match_count, alias_shift, seed in cases:
+            with self.subTest(shift=shift, orb_match_count=orb_match_count):
+                before = _complex_scene(height=760, width=240, seed=seed)
+                after = _shift_up(before, shift, seed=seed + 100)
+                sparse_orb = MotionHypothesis(
+                    matches=[object()] * orb_match_count,
+                    shift_y=float(shift),
+                    median_abs_deviation=1.0,
+                    x_coverage=0.40,
+                    y_coverage=0.35,
+                    mean_descriptor_distance=45.0,
+                )
+                periodic_alias = MotionHypothesis(
+                    matches=[object()] * 20,
+                    shift_y=float(alias_shift),
+                    median_abs_deviation=1.0,
+                    x_coverage=0.70,
+                    y_coverage=0.70,
+                    mean_descriptor_distance=24.0,
+                )
+                with mock.patch.object(
+                    _MODULE,
+                    "_cluster_positive_vertical_matches",
+                    return_value=[periodic_alias, sparse_orb],
+                ):
+                    estimate = estimate_vertical_motion(
+                        before, after, (25, 700), (30, 700)
+                    )
+                self.assertAlmostEqual(estimate.shift_y, shift, delta=2)
+                self.assertEqual(
+                    estimate.selected_hypothesis["proposal_source"], "merged"
+                )
+                self.assertEqual(
+                    estimate.selected_hypothesis["match_count"], orb_match_count
+                )
+                self.assertEqual(
+                    estimate.selected_hypothesis["selection_mode"],
+                    "normal_motion_full_overlap",
+                )
+                self.assertFalse(estimate.selected_hypothesis["fallback_used"])
+                self.assertTrue(estimate.direct_normal_search["candidate_injected"])
+
+    def test_merged_without_validated_direct_support_stays_out_of_normal_pool(self):
+        alias = MotionHypothesis(
+            matches=[object()] * 20,
+            shift_y=268.0,
+            median_abs_deviation=1.0,
+            x_coverage=0.70,
+            y_coverage=0.70,
+            mean_descriptor_distance=24.0,
+        )
+        merged_without_direct = MotionHypothesis(
+            matches=[object()],
+            shift_y=601.0,
+            median_abs_deviation=1.0,
+            x_coverage=0.40,
+            y_coverage=0.35,
+            mean_descriptor_distance=45.0,
+            anchor_score=0.96,
+            anchor_height_px=120,
+            full_overlap_score=0.95,
+            full_overlap_height_px=147,
+            full_overlap_gray_score=0.95,
+            full_overlap_gradient_score=0.95,
+            proposal_source="merged",
+        )
+        selected, reason, _ = select_motion_hypothesis(
+            [alias, merged_without_direct],
+            (25, 700),
+            (30, 700),
+            {
+                "candidate_injected": False,
+                "best_shift_px": 601,
+                "best_score": 0.95,
+            },
+        )
+        self.assertIsNotNone(selected)
+        self.assertEqual(reason["normal_motion_candidate_count"], 0)
+        self.assertEqual(reason["selection_mode"], "terminal_fallback")
+        self.assertTrue(reason["fallback_used"])
+
+    def test_direct_normal_search_does_not_inject_for_terminal_or_no_move(self):
+        before = np.random.default_rng(811).integers(
+            0, 256, size=(760, 240, 3), dtype=np.uint8
+        )
+        for candidate in (before.copy(), _shift_up(before, 200, seed=812)):
+            with self.subTest(candidate="no_move" if candidate is before else "terminal"):
+                direct, diagnostics = find_direct_normal_band_candidate(before, candidate)
+                self.assertIsNone(direct)
+                self.assertFalse(diagnostics["candidate_injected"])
+
+    def test_full_overlap_requires_at_least_eighty_shared_pixels(self):
+        before = np.random.default_rng(805).integers(
+            0, 256, size=(760, 240, 3), dtype=np.uint8
+        )
+        after = _shift_up(before, 690, seed=806)
+        insufficient = MotionHypothesis(
+            matches=[object()] * 8,
+            shift_y=690.0,
+            median_abs_deviation=1.0,
+            x_coverage=0.50,
+            y_coverage=0.50,
+            mean_descriptor_distance=30.0,
+        )
+        apply_direct_overlap_anchors([insufficient], before, after)
+        self.assertIsNone(insufficient.full_overlap_score)
+        self.assertEqual(insufficient.full_overlap_height_px, 0)
+
+    def test_semantic_zero_overlap_target_keeps_visual_overlap_out_of_ocr_pair(self):
+        before = np.random.default_rng(811).integers(
+            0, 256, size=(720, 260, 3), dtype=np.uint8
+        )
+        target = evaluate_feedback_candidate(
+            before, _shift_up(before, 620, seed=812), _b1d_feedback_config()
+        )
+        self.assertTrue(target["accepted"])
+        self.assertEqual(target["efficiency_status"], "semantic_zero_overlap_target")
+        self.assertGreater(target["physical_overlap_px"], 0)
+        self.assertTrue(target["visual_overlap"])
+        self.assertFalse(target["ocr_overlap_pair_required"])
+        self.assertIsNone(target["relation"])
+        self.assertEqual(target["target_shift_range"], [610, 630])
+        self.assertEqual(target["safe_shift_range"], [560, 650])
+        self.assertEqual(target["physical_shift_range"], [30, 700])
+
+    def test_case_a_593px_keeps_semantic_zero_overlap(self):
+        before = _complex_scene(height=760, width=240, seed=921)
+        result = evaluate_feedback_candidate(
+            before, _shift_up(before, 593, seed=922), _b1d_feedback_config()
+        )
+        self.assertAlmostEqual(result["actual_shift_px"], 593, delta=3)
+        self.assertEqual(
+            result["semantic_overlap_state"], "definitely_no_full_row"
+        )
+        self.assertFalse(result["ocr_overlap_pair_required"])
+
+    def test_normal_acceptance_allows_one_pixel_estimation_boundary(self):
+        before = _complex_scene(height=760, width=240, seed=941)
+        candidate = _shift_up(before, 600, seed=942)
+        estimate = estimate_vertical_motion(before, candidate, (250, 700), (30, 700))
+        for measured_shift in (599.6, 599.0):
+            with self.subTest(measured_shift=measured_shift):
+                with mock.patch.object(
+                    _MODULE,
+                    "estimate_vertical_motion",
+                    return_value=replace(estimate, shift_y=measured_shift),
+                ):
+                    result = evaluate_feedback_candidate(
+                        before, candidate, _b1d_feedback_config()
+                    )
+                self.assertTrue(result["accepted"])
+                self.assertEqual(result["reason"], "diagnostic_only")
+                self.assertEqual(
+                    result["efficiency_status"], "semantic_zero_overlap_acceptable"
+                )
+
+    def test_normal_acceptance_epsilon_does_not_admit_596px(self):
+        before = _complex_scene(height=760, width=240, seed=951)
+        result = evaluate_feedback_candidate(
+            before, _shift_up(before, 596, seed=952), _b1d_feedback_config()
+        )
+        self.assertFalse(result["accepted"])
+        self.assertEqual(result["reason"], "efficiency_correction_required")
+        self.assertEqual(result["efficiency_status"], "conservative")
+
+    def test_feedback_metrics_contract_keeps_only_final_control_and_diagnostics(self):
+        before = _complex_scene(height=760, width=240, seed=931)
+        evaluation = evaluate_feedback_candidate(
+            before, _shift_up(before, 620, seed=932), _b1d_feedback_config()
+        )
+        evaluation["section_complete"] = False
+        evaluation["image_pair"] = None
+        result = feedback_metrics_contract(evaluation)
+        for removed in (
+            "shift_estimate",
+            "same_position_score",
+            "local_overlap_score",
+            "local_overlap_valid",
+            "reason",
+            "efficiency_status",
+            "row_lattice",
+            "full_row_candidates",
+            "attempts",
+        ):
+            self.assertNotIn(removed, result)
+        self.assertEqual(
+            set(result),
+            {
+                "accepted",
+                "relation",
+                "ocr_overlap_pair_required",
+                "semantic_overlap_state",
+                "section_complete",
+                "image_pair",
+                "diagnostics",
+            },
+        )
+        self.assertEqual(
+            set(result["diagnostics"]),
+            {"actual_shift_px", "motion_reliability", "physical_overlap_px"},
+        )
+
+    def test_low_orb_confidence_with_strong_merged_direct_evidence_is_reliable(self):
+        before = _complex_scene(height=760, width=240, seed=901)
+        candidate = _shift_up(before, 620, seed=902)
+        estimate = estimate_vertical_motion(before, candidate, (250, 700), (30, 700))
+        self.assertEqual(estimate.selected_hypothesis["proposal_source"], "merged")
+        self.assertEqual(
+            estimate.selected_hypothesis["selection_mode"],
+            "normal_motion_full_overlap",
+        )
+        self.assertTrue(estimate.direct_normal_search["candidate_injected"])
+        low_orb_confidence = replace(estimate, confidence=0.01)
+        with mock.patch.object(
+            _MODULE, "estimate_vertical_motion", return_value=low_orb_confidence
+        ):
+            result = evaluate_feedback_candidate(
+                before, candidate, _b1d_feedback_config()
+            )
+        self.assertTrue(result["accepted"])
+        self.assertNotEqual(
+            result["semantic_overlap_state"], "not_applicable_unreliable_motion"
+        )
+        self.assertFalse(result["motion_reliability"]["orb_confidence_passed"])
+        self.assertTrue(
+            result["motion_reliability"]["direct_normal_evidence_passed"]
+        )
+        self.assertTrue(result["motion_reliability"]["reliable"])
+        self.assertEqual(
+            result["motion_reliability"]["mode"], "direct_normal_full_overlap"
+        )
+        self.assertFalse(result["ocr_overlap_pair_required"])
+        self.assertIsNone(result["relation"])
+
+    def test_low_confidence_without_strong_direct_evidence_remains_unreliable(self):
+        before = _complex_scene(height=760, width=240, seed=911)
+        candidate = _shift_up(before, 620, seed=912)
+        estimate = estimate_vertical_motion(before, candidate, (250, 700), (30, 700))
+        weakened_hypothesis = {
+            **estimate.selected_hypothesis,
+            "proposal_source": "orb",
+        }
+        weakened = replace(
+            estimate,
+            confidence=0.01,
+            selected_hypothesis=weakened_hypothesis,
+        )
+        with mock.patch.object(
+            _MODULE, "estimate_vertical_motion", return_value=weakened
+        ):
+            result = evaluate_feedback_candidate(
+                before, candidate, _b1d_feedback_config()
+            )
+        self.assertFalse(result["accepted"])
+        self.assertEqual(
+            result["semantic_overlap_state"],
+            "not_applicable_unreliable_motion",
+        )
+        self.assertEqual(result["motion_reliability"]["mode"], "unreliable")
+        self.assertFalse(result["motion_reliability"]["reliable"])
+        self.assertFalse(
+            result["motion_reliability"]["direct_normal_evidence_passed"]
+        )
+        self.assertFalse(result["ocr_overlap_pair_required"])
+        self.assertIsNone(result["relation"])
+
+    def test_direct_anchor_resolves_periodic_alias_in_favor_of_true_shift(self):
+        before = np.random.default_rng(814).integers(
+            0, 256, size=(760, 240, 3), dtype=np.uint8
+        )
+        after = _shift_up(before, 522, seed=815)
+        periodic_alias = MotionHypothesis(
+            matches=[object()] * 220,
+            shift_y=356.0,
+            median_abs_deviation=1.0,
+            x_coverage=0.90,
+            y_coverage=0.90,
+            mean_descriptor_distance=15.0,
+        )
+        true_shift = MotionHypothesis(
+            matches=[object()] * 12,
+            shift_y=522.0,
+            median_abs_deviation=1.0,
+            x_coverage=0.35,
+            y_coverage=0.35,
+            mean_descriptor_distance=45.0,
+        )
+        hypotheses = [periodic_alias, true_shift]
+        apply_direct_overlap_anchors(hypotheses, before, after)
+        selected, reason, _ = select_motion_hypothesis(hypotheses, (250, 700), (30, 700))
+        self.assertIs(selected, true_shift)
+        self.assertGreater(true_shift.anchor_score, periodic_alias.anchor_score)
+        self.assertEqual(reason["anchor_score"], true_shift.anchor_score)
+
+    def test_efficiency_risk_gets_one_micro_retry_from_original_prev(self):
+        prev = np.random.default_rng(816).integers(
+            0, 256, size=(760, 240, 3), dtype=np.uint8
+        )
+        under_advanced = _shift_up(prev, 560, seed=817)
+        corrected = _shift_up(prev, 620, seed=818)
+        params = {
+            "mode": "feedback_probe",
+            "debug_dir": "unused",
+            "compare_roi": [0, 0, 240, 760],
+            "coarse_swipe": {
+                "start": [360, 930], "end": [360, 470], "duration_ms": 700
+            },
+            "micro_swipe": {
+                "start": [360, 930], "end": [360, 800], "duration_ms": 500
+            },
+            "settle_ms": 0,
+            "feedback": _b1d_feedback_config(),
+        }
+        initial = evaluate_feedback_candidate(prev, under_advanced, params["feedback"])
+        self.assertEqual(initial["reason"], "efficiency_correction_required")
+        with tempfile.TemporaryDirectory() as directory:
+            params["debug_dir"] = directory
+            context = _FakeCaptureContext([prev, under_advanced, corrected])
+            result = StarBackpackCaptureProbe().run(
+                context, SimpleNamespace(custom_action_param=params)
+            )
+            self.assertTrue(getattr(result, "success", False))
+            run_dir = next(Path(directory).iterdir())
+            metrics = json.loads(
+                (run_dir / "feedback-metrics.json").read_text(encoding="utf-8")
+            )
+            self.assertTrue(metrics["accepted"])
+            self.assertFalse(metrics["ocr_overlap_pair_required"])
+            self.assertIsNone(metrics["image_pair"])
+            self.assertEqual(len(context.tasker.controller.swipes), 2)
+
+    def test_single_swipe_calibration_ends_after_coarse_for_every_diagnostic_reason(self):
+        calibration_cases = (
+            (
+                "efficiency_correction_required",
+                np.random.default_rng(816).integers(
+                    0, 256, size=(760, 240, 3), dtype=np.uint8
+                ),
+                560,
+                817,
+            ),
+            (
+                "terminal_partial_candidate",
+                _complex_scene(height=480, width=240, seed=853),
+                200,
+                854,
+            ),
+            (
+                "unsafe_gap_risk",
+                np.random.default_rng(855).integers(
+                    0, 256, size=(720, 240, 3), dtype=np.uint8
+                ),
+                660,
+                856,
+            ),
+            (
+                "bottom_no_move",
+                _complex_scene(height=480, width=240, seed=857),
+                0,
+                858,
+            ),
+        )
+        for expected_reason, prev, shift, seed in calibration_cases:
+            with self.subTest(reason=expected_reason):
+                candidate = (
+                    prev.copy() if shift == 0 else _shift_up(prev, shift, seed=seed)
+                )
+                height, width = prev.shape[:2]
+                params = {
+                    "mode": "feedback_probe",
+                    "single_swipe_calibration": True,
+                    "debug_dir": "unused",
+                    "compare_roi": [0, 0, width, height],
+                    "coarse_swipe": {
+                        "start": [360, 930], "end": [360, 500], "duration_ms": 700
+                    },
+                    "micro_swipe": {
+                        "start": [360, 930], "end": [360, 800], "duration_ms": 500
+                    },
+                    "settle_ms": 0,
+                    "feedback": _b1d_feedback_config(),
+                }
+                self.assertEqual(
+                    evaluate_feedback_candidate(prev, candidate, params["feedback"])[
+                        "reason"
+                    ],
+                    expected_reason,
+                )
+                with tempfile.TemporaryDirectory() as directory:
+                    params["debug_dir"] = directory
+                    context = _FakeCaptureContext([prev, candidate, candidate])
+                    result = StarBackpackCaptureProbe().run(
+                        context, SimpleNamespace(custom_action_param=params)
+                    )
+                    self.assertTrue(getattr(result, "success", False))
+                    run_dir = next(Path(directory).iterdir())
+                    metrics = json.loads(
+                        (run_dir / "feedback-metrics.json").read_text(encoding="utf-8")
+                    )
+                    self.assertNotIn("reason", metrics)
+                    self.assertNotIn("single_swipe_calibration", metrics)
+                    self.assertNotIn("attempts", metrics)
+                    self.assertEqual(len(context.tasker.controller.swipes), 1)
+                    self.assertTrue((run_dir / "prev.png").is_file())
+                    self.assertTrue((run_dir / "prev-roi.png").is_file())
+                    self.assertTrue((run_dir / "candidate.png").is_file())
+                    self.assertTrue((run_dir / "candidate-roi.png").is_file())
+
+    def test_reliable_small_positive_motion_is_terminal_partial_candidate(self):
+        before = _complex_scene(height=480, width=240, seed=821)
+        result = evaluate_feedback_candidate(
+            before, _shift_up(before, 200, seed=822), _b1d_feedback_config()
+        )
+        self.assertFalse(result["accepted"])
+        self.assertEqual(result["reason"], "terminal_partial_candidate")
+        self.assertEqual(result["efficiency_status"], "terminal_partial")
+        self.assertIn(
+            result["semantic_overlap_state"],
+            {"definitely_no_full_row", "ambiguous", "definitely_full_row"},
+        )
+
+    def test_terminal_partial_is_accepted_only_after_no_move_confirmation(self):
+        prev = _complex_scene(height=480, width=240, seed=831)
+        partial = _shift_up(prev, 200, seed=832)
+        params = {
+            "mode": "feedback_probe",
+            "debug_dir": "unused",
+            "compare_roi": [0, 0, 240, 480],
+            "coarse_swipe": {
+                "start": [360, 930], "end": [360, 600], "duration_ms": 700
+            },
+            "micro_swipe": {
+                "start": [360, 930], "end": [360, 800], "duration_ms": 500
+            },
+            "settle_ms": 0,
+            "feedback": _b1d_feedback_config(),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            params["debug_dir"] = directory
+            context = _FakeCaptureContext([prev, partial, partial])
+            result = StarBackpackCaptureProbe().run(
+                context, SimpleNamespace(custom_action_param=params)
+            )
+            self.assertTrue(getattr(result, "success", False))
+            run_dir = next(Path(directory).iterdir())
+            metrics = json.loads(
+                (run_dir / "feedback-metrics.json").read_text(encoding="utf-8")
+            )
+            self.assertTrue(metrics["accepted"])
+            self.assertTrue(metrics["section_complete"])
+            self.assertTrue((run_dir / "candidate.png").is_file())
+            self.assertFalse((run_dir / "candidate-02.png").exists())
+
+    def test_terminal_confirmation_omits_relation_without_semantic_pair(self):
+        prev = _complex_scene(height=760, width=240, seed=834)
+        partial = _shift_up(prev, 650, seed=835)
+        feedback = _b1d_feedback_config()
+        feedback["diagnostic_safe_shift_px"] = (700, 710)
+        feedback["diagnostic_normal_safe_shift_px"] = (700, 710)
+        feedback["diagnostic_micro_trigger_shift_px"] = 700
+        params = {
+            "mode": "feedback_probe",
+            "debug_dir": "unused",
+            "compare_roi": [0, 0, 240, 760],
+            "coarse_swipe": {
+                "start": [360, 930], "end": [360, 600], "duration_ms": 700
+            },
+            "micro_swipe": {
+                "start": [360, 930], "end": [360, 800], "duration_ms": 500
+            },
+            "settle_ms": 0,
+            "feedback": feedback,
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            params["debug_dir"] = directory
+            context = _FakeCaptureContext([prev, partial, partial])
+            result = StarBackpackCaptureProbe().run(
+                context, SimpleNamespace(custom_action_param=params)
+            )
+            self.assertTrue(getattr(result, "success", False))
+            run_dir = next(Path(directory).iterdir())
+            metrics = json.loads(
+                (run_dir / "feedback-metrics.json").read_text(encoding="utf-8")
+            )
+        self.assertTrue(metrics["accepted"])
+        self.assertTrue(metrics["section_complete"])
+        self.assertFalse(metrics["ocr_overlap_pair_required"])
+        self.assertIsNone(metrics["relation"])
+        self.assertIsNone(metrics["image_pair"])
+
+    def test_terminal_confirmation_that_moves_rejoins_normal_feedback(self):
+        prev = _complex_scene(height=720, width=240, seed=836)
+        partial = _shift_up(prev, 200, seed=837)
+        normal_candidate = _shift_up(prev, 620, seed=838)
+        params = {
+            "mode": "feedback_probe",
+            "debug_dir": "unused",
+            "compare_roi": [0, 0, 240, 720],
+            "coarse_swipe": {
+                "start": [360, 930], "end": [360, 600], "duration_ms": 700
+            },
+            "micro_swipe": {
+                "start": [360, 930], "end": [360, 800], "duration_ms": 500
+            },
+            "settle_ms": 0,
+            "feedback": _b1d_feedback_config(),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            params["debug_dir"] = directory
+            context = _FakeCaptureContext([prev, partial, normal_candidate])
+            result = StarBackpackCaptureProbe().run(
+                context, SimpleNamespace(custom_action_param=params)
+            )
+            self.assertTrue(getattr(result, "success", False))
+            run_dir = next(Path(directory).iterdir())
+            metrics = json.loads(
+                (run_dir / "feedback-metrics.json").read_text(encoding="utf-8")
+            )
+            self.assertTrue(metrics["accepted"])
+            self.assertFalse(metrics["ocr_overlap_pair_required"])
+            self.assertIsNone(metrics["image_pair"])
+            self.assertFalse(metrics["section_complete"])
+            self.assertEqual(len(context.tasker.controller.swipes), 2)
+
+    def test_true_overshoot_remains_fail_safe(self):
+        before = _complex_scene(height=720, width=260, seed=841)
+        result = evaluate_feedback_candidate(
+            before, _shift_up(before, 660, seed=842), _b1d_feedback_config()
+        )
+        self.assertFalse(result["accepted"])
+        self.assertEqual(result["reason"], "unsafe_gap_risk")
+
+
+class StarBackpackContinuousCaptureTests(unittest.TestCase):
+    def _session(self, directory):
+        run_dir = next(Path(directory).iterdir())
+        return run_dir, json.loads((run_dir / "session.json").read_text(encoding="utf-8"))
+
+    def test_multiple_normal_transitions_keep_every_business_screenshot_until_bottom(self):
+        initial = _complex_scene(height=760, width=240, seed=1401)
+        first = _shift_up(initial, 620, seed=1402)
+        second = _shift_up(first, 620, seed=1403)
+        with tempfile.TemporaryDirectory() as directory:
+            context = _FakeCaptureContext([initial, first, second, second])
+            result = StarBackpackCaptureProbe().run(
+                context,
+                SimpleNamespace(
+                    custom_action_param=_continuous_capture_params(directory)
+                ),
+            )
+            run_dir, session = self._session(directory)
+            has_last_retained_image = (run_dir / "capture-02.png").is_file()
+            has_extra_retained_image = (run_dir / "capture-03.png").exists()
+            has_failed_candidate = (run_dir / "failed-candidate-03.png").exists()
+
+        self.assertTrue(getattr(result, "success", False))
+        self.assertEqual(session["stop_reason"], "bottom_no_move")
+        self.assertEqual(session["transition_count"], 3)
+        self.assertEqual(session["retained_images"], [
+            "capture-00.png", "capture-01.png", "capture-02.png",
+        ])
+        self.assertEqual(session["retained_image_count"], 3)
+        self.assertEqual(session["adjacent_relations"], [])
+        self.assertIsNone(session["failed_transition"])
+        self.assertEqual(len(context.tasker.controller.swipes), 3)
+        self.assertTrue(has_last_retained_image)
+        self.assertFalse(has_extra_retained_image)
+        self.assertFalse(has_failed_candidate)
+
+    def test_physical_overlap_without_full_row_still_keeps_next_screenshot(self):
+        initial = _complex_scene(height=760, width=240, seed=1411)
+        next_image = _shift_up(initial, 620, seed=1412)
+        initial_evaluation = evaluate_feedback_candidate(
+            initial, next_image, _b1d_feedback_config()
+        )
+        self.assertGreater(initial_evaluation["physical_overlap_px"], 0)
+        self.assertEqual(
+            initial_evaluation["semantic_overlap_state"], "definitely_no_full_row"
+        )
+        self.assertFalse(initial_evaluation["ocr_overlap_pair_required"])
+
+        with tempfile.TemporaryDirectory() as directory:
+            context = _FakeCaptureContext([initial, next_image, next_image])
+            result = StarBackpackCaptureProbe().run(
+                context,
+                SimpleNamespace(
+                    custom_action_param=_continuous_capture_params(directory)
+                ),
+            )
+            _, session = self._session(directory)
+
+        self.assertTrue(getattr(result, "success", False))
+        self.assertEqual(session["retained_image_count"], 2)
+        self.assertEqual(session["adjacent_relations"], [])
+        self.assertEqual(len(context.tasker.controller.swipes), 2)
+
+    def test_593px_reliable_under_target_is_retained_until_bottom(self):
+        initial = _complex_scene(height=760, width=240, seed=1471)
+        candidate = _shift_up(initial, 593, seed=1472)
+        evaluation = evaluate_feedback_candidate(
+            initial, candidate, _b1d_feedback_config()
+        )
+        self.assertFalse(evaluation["accepted"])
+        self.assertEqual(
+            evaluation["semantic_overlap_state"], "definitely_no_full_row"
+        )
+        self.assertNotEqual(evaluation["motion_reliability"]["mode"], "unreliable")
+
+        with tempfile.TemporaryDirectory() as directory:
+            context = _FakeCaptureContext([initial, candidate, candidate])
+            result = StarBackpackCaptureProbe().run(
+                context,
+                SimpleNamespace(
+                    custom_action_param=_continuous_capture_params(directory)
+                ),
+            )
+            run_dir, session = self._session(directory)
+            partial_was_retained = (run_dir / "capture-01.png").is_file()
+
+        self.assertTrue(getattr(result, "success", False))
+        self.assertEqual(session["stop_reason"], "bottom_no_move")
+        self.assertEqual(session["retained_image_count"], 2)
+        self.assertTrue(partial_was_retained)
+        self.assertEqual(len(context.tasker.controller.swipes), 2)
+
+    def test_596px_efficiency_under_target_remains_capture_safe_progress(self):
+        initial = _complex_scene(height=760, width=240, seed=1481)
+        candidate = _shift_up(initial, 596, seed=1482)
+        evaluation = evaluate_feedback_candidate(
+            initial, candidate, _b1d_feedback_config()
+        )
+        self.assertFalse(evaluation["accepted"])
+        self.assertNotEqual(evaluation["motion_reliability"]["mode"], "unreliable")
+
+        with tempfile.TemporaryDirectory() as directory:
+            context = _FakeCaptureContext([initial, candidate, candidate])
+            result = StarBackpackCaptureProbe().run(
+                context,
+                SimpleNamespace(
+                    custom_action_param=_continuous_capture_params(directory)
+                ),
+            )
+            _, session = self._session(directory)
+
+        self.assertTrue(getattr(result, "success", False))
+        self.assertEqual(session["retained_image_count"], 2)
+        self.assertEqual(len(context.tasker.controller.swipes), 2)
+
+    def test_reliable_terminal_partial_is_retained_before_next_no_move(self):
+        initial = _complex_scene(height=480, width=240, seed=1491)
+        candidate = _shift_up(initial, 200, seed=1492)
+        evaluation = evaluate_feedback_candidate(
+            initial, candidate, _b1d_feedback_config()
+        )
+        self.assertFalse(evaluation["accepted"])
+        self.assertEqual(evaluation["reason"], "terminal_partial_candidate")
+        self.assertNotEqual(evaluation["motion_reliability"]["mode"], "unreliable")
+
+        with tempfile.TemporaryDirectory() as directory:
+            context = _FakeCaptureContext([initial, candidate, candidate])
+            result = StarBackpackCaptureProbe().run(
+                context,
+                SimpleNamespace(
+                    custom_action_param=_continuous_capture_params(
+                        directory, height=480
+                    )
+                ),
+            )
+            run_dir, session = self._session(directory)
+            partial_was_retained = (run_dir / "capture-01.png").is_file()
+
+        self.assertTrue(getattr(result, "success", False))
+        self.assertEqual(session["stop_reason"], "bottom_no_move")
+        self.assertEqual(session["retained_image_count"], 2)
+        self.assertTrue(partial_was_retained)
+        self.assertEqual(len(context.tasker.controller.swipes), 2)
+
+    def test_reliable_660px_overshoot_remains_rejected(self):
+        initial = _complex_scene(height=900, width=240, seed=1501)
+        candidate = _shift_up(initial, 660, seed=1502)
+        evaluation = evaluate_feedback_candidate(
+            initial, candidate, _b1d_feedback_config()
+        )
+        self.assertFalse(evaluation["accepted"])
+        self.assertGreater(evaluation["actual_shift_px"], 650)
+        self.assertNotEqual(evaluation["motion_reliability"]["mode"], "unreliable")
+
+        with tempfile.TemporaryDirectory() as directory:
+            context = _FakeCaptureContext([initial, candidate])
+            result = StarBackpackCaptureProbe().run(
+                context,
+                SimpleNamespace(
+                    custom_action_param=_continuous_capture_params(
+                        directory, height=900
+                    )
+                ),
+            )
+            _, session = self._session(directory)
+
+        self.assertFalse(getattr(result, "success", True))
+        self.assertEqual(session["stop_reason"], "rejected_transition")
+        self.assertEqual(session["failed_transition"], 1)
+        self.assertGreater(session["diagnostics"]["last_actual_shift_px"], 650)
+        self.assertEqual(len(context.tasker.controller.swipes), 1)
+
+    def test_651px_reliable_progress_is_retained_despite_semantic_failsafe_state(self):
+        feedback = _b1d_feedback_config()
+        transition = {
+            "diagnostics": {
+                "motion_reliability": "orb_confidence",
+                "actual_shift_px": 651.0,
+            }
+        }
+        self.assertTrue(is_capture_safe_progress(transition, feedback))
+
+        initial = _complex_scene(height=760, width=240, seed=1511)
+        candidate = _shift_up(initial, 620, seed=1512)
+        b1_results = [
+            _b1_transition_evaluation(
+                "not_applicable_unreliable_motion",
+                False,
+                actual_shift_px=651.0,
+            ),
+            _b1_transition_evaluation("not_applicable_no_move", False),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            context = _FakeCaptureContext([initial, candidate, candidate])
+            with mock.patch.object(
+                _MODULE, "evaluate_feedback_candidate", side_effect=b1_results
+            ):
+                result = StarBackpackCaptureProbe().run(
+                    context,
+                    SimpleNamespace(
+                        custom_action_param=_continuous_capture_params(directory)
+                    ),
+                )
+            run_dir, session = self._session(directory)
+            candidate_was_retained = (run_dir / "capture-01.png").is_file()
+
+        self.assertTrue(getattr(result, "success", False))
+        self.assertEqual(session["stop_reason"], "bottom_no_move")
+        self.assertEqual(session["retained_images"], ["capture-00.png", "capture-01.png"])
+        self.assertTrue(candidate_was_retained)
+        self.assertEqual(len(context.tasker.controller.swipes), 2)
+
+    def test_652px_reliable_progress_is_not_accepted_by_one_pixel_tolerance(self):
+        feedback = _b1d_feedback_config()
+        transition = {
+            "diagnostics": {
+                "motion_reliability": "orb_confidence",
+                "actual_shift_px": 652.0,
+            }
+        }
+        self.assertFalse(is_capture_safe_progress(transition, feedback))
+
+        initial = _complex_scene(height=760, width=240, seed=1521)
+        candidate = _shift_up(initial, 620, seed=1522)
+        with tempfile.TemporaryDirectory() as directory:
+            context = _FakeCaptureContext([initial, candidate])
+            with mock.patch.object(
+                _MODULE,
+                "evaluate_feedback_candidate",
+                return_value=_b1_transition_evaluation(
+                    "definitely_no_full_row",
+                    False,
+                    actual_shift_px=652.0,
+                ),
+            ):
+                result = StarBackpackCaptureProbe().run(
+                    context,
+                    SimpleNamespace(
+                        custom_action_param=_continuous_capture_params(directory)
+                    ),
+                )
+            run_dir, session = self._session(directory)
+            failed_candidate_exists = (run_dir / "failed-candidate-01.png").is_file()
+
+        self.assertFalse(getattr(result, "success", True))
+        self.assertEqual(session["stop_reason"], "rejected_transition")
+        self.assertEqual(session["retained_images"], ["capture-00.png"])
+        self.assertTrue(failed_candidate_exists)
+        self.assertEqual(len(context.tasker.controller.swipes), 1)
+
+    def test_full_and_ambiguous_semantic_overlap_preserve_both_next_screenshots(self):
+        initial = _complex_scene(height=760, width=240, seed=1421)
+        first = _shift_up(initial, 620, seed=1422)
+        second = _shift_up(first, 620, seed=1423)
+        b1_results = [
+            _b1_transition_evaluation("definitely_full_row", True),
+            _b1_transition_evaluation("ambiguous", True),
+            _b1_transition_evaluation("not_applicable_no_move", False),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            context = _FakeCaptureContext([initial, first, second, second])
+            with mock.patch.object(
+                _MODULE, "evaluate_feedback_candidate", side_effect=b1_results
+            ):
+                result = StarBackpackCaptureProbe().run(
+                    context,
+                    SimpleNamespace(
+                        custom_action_param=_continuous_capture_params(directory)
+                    ),
+                )
+            _, session = self._session(directory)
+
+        self.assertTrue(getattr(result, "success", False))
+        self.assertEqual(session["retained_image_count"], 3)
+        self.assertEqual(
+            session["adjacent_relations"],
+            [
+                {
+                    "previous_image": "capture-00.png",
+                    "current_image": "capture-01.png",
+                    "relation": "overlap",
+                },
+                {
+                    "previous_image": "capture-01.png",
+                    "current_image": "capture-02.png",
+                    "relation": "overlap",
+                },
+            ],
+        )
+        self.assertEqual(session["stop_reason"], "bottom_no_move")
+        self.assertEqual(len(context.tasker.controller.swipes), 3)
+
+    def test_ambiguous_safe_progress_retains_required_overlap_when_b1_is_not_accepted(self):
+        initial = _complex_scene(height=760, width=240, seed=1424)
+        candidate = _shift_up(initial, 620, seed=1425)
+        b1_results = [
+            _b1_transition_evaluation(
+                "ambiguous", False, actual_shift_px=620.0
+            ),
+            _b1_transition_evaluation("not_applicable_no_move", False),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            context = _FakeCaptureContext([initial, candidate, candidate])
+            with mock.patch.object(
+                _MODULE, "evaluate_feedback_candidate", side_effect=b1_results
+            ):
+                result = StarBackpackCaptureProbe().run(
+                    context,
+                    SimpleNamespace(
+                        custom_action_param=_continuous_capture_params(directory)
+                    ),
+                )
+            _, session = self._session(directory)
+
+        self.assertTrue(getattr(result, "success", False))
+        self.assertFalse(b1_results[0]["accepted"])
+        self.assertEqual(session["retained_images"], ["capture-00.png", "capture-01.png"])
+        self.assertEqual(
+            session["adjacent_relations"],
+            [
+                {
+                    "previous_image": "capture-00.png",
+                    "current_image": "capture-01.png",
+                    "relation": "overlap",
+                }
+            ],
+        )
+
+    def test_only_the_final_required_pair_is_handed_off_across_six_retained_images(self):
+        initial = _complex_scene(height=760, width=240, seed=1426)
+        images = [initial]
+        for index in range(1, 6):
+            images.append(_shift_up(images[-1], 620, seed=1426 + index))
+        b1_results = [
+            _b1_transition_evaluation("definitely_no_full_row", True),
+            _b1_transition_evaluation("definitely_no_full_row", True),
+            _b1_transition_evaluation("definitely_no_full_row", True),
+            _b1_transition_evaluation("definitely_no_full_row", True),
+            _b1_transition_evaluation(
+                "ambiguous", False, actual_shift_px=620.0
+            ),
+            _b1_transition_evaluation("not_applicable_no_move", False),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            context = _FakeCaptureContext([*images, images[-1]])
+            with mock.patch.object(
+                _MODULE, "evaluate_feedback_candidate", side_effect=b1_results
+            ):
+                result = StarBackpackCaptureProbe().run(
+                    context,
+                    SimpleNamespace(
+                        custom_action_param=_continuous_capture_params(
+                            directory, max_transitions=6
+                        )
+                    ),
+                )
+            _, session = self._session(directory)
+
+        self.assertTrue(getattr(result, "success", False))
+        self.assertEqual(session["stop_reason"], "bottom_no_move")
+        self.assertEqual(session["retained_image_count"], 6)
+        self.assertEqual(
+            session["adjacent_relations"],
+            [
+                {
+                    "previous_image": "capture-04.png",
+                    "current_image": "capture-05.png",
+                    "relation": "overlap",
+                }
+            ],
+        )
+        self.assertEqual(len(context.tasker.controller.swipes), 6)
+
+    def test_bottom_confirmation_reconciles_a_missing_final_overlap_relation(self):
+        initial = _complex_scene(height=760, width=240, seed=1430)
+        candidate = _shift_up(initial, 620, seed=1431)
+        b1_results = [
+            _b1_transition_evaluation("definitely_no_full_row", True),
+            _b1_transition_evaluation("not_applicable_no_move", False),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            context = _FakeCaptureContext([initial, candidate, candidate])
+            with mock.patch.object(
+                _MODULE, "evaluate_feedback_candidate", side_effect=b1_results
+            ), mock.patch.object(
+                _MODULE,
+                "_terminal_confirmed_overlap_pair_required",
+                return_value=True,
+            ) as reconcile:
+                result = StarBackpackCaptureProbe().run(
+                    context,
+                    SimpleNamespace(
+                        custom_action_param=_continuous_capture_params(directory)
+                    ),
+                )
+            _, session = self._session(directory)
+
+        self.assertTrue(getattr(result, "success", False))
+        self.assertEqual(session["stop_reason"], "bottom_no_move")
+        self.assertEqual(
+            session["adjacent_relations"],
+            [
+                {
+                    "previous_image": "capture-00.png",
+                    "current_image": "capture-01.png",
+                    "relation": "overlap",
+                }
+            ],
+        )
+        reconcile.assert_called_once()
+
+    def test_bottom_confirmation_does_not_add_final_relation_without_semantic_pair(self):
+        initial = _complex_scene(height=760, width=240, seed=1432)
+        candidate = _shift_up(initial, 620, seed=1433)
+        b1_results = [
+            _b1_transition_evaluation("definitely_no_full_row", True),
+            _b1_transition_evaluation("not_applicable_no_move", False),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            context = _FakeCaptureContext([initial, candidate, candidate])
+            with mock.patch.object(
+                _MODULE, "evaluate_feedback_candidate", side_effect=b1_results
+            ), mock.patch.object(
+                _MODULE,
+                "_terminal_confirmed_overlap_pair_required",
+                return_value=False,
+            ) as reconcile:
+                result = StarBackpackCaptureProbe().run(
+                    context,
+                    SimpleNamespace(
+                        custom_action_param=_continuous_capture_params(directory)
+                    ),
+                )
+            _, session = self._session(directory)
+
+        self.assertTrue(getattr(result, "success", False))
+        self.assertEqual(session["adjacent_relations"], [])
+        reconcile.assert_called_once()
+
+    def test_bottom_confirmation_does_not_duplicate_an_existing_final_relation(self):
+        initial = _complex_scene(height=760, width=240, seed=1434)
+        candidate = _shift_up(initial, 620, seed=1435)
+        b1_results = [
+            _b1_transition_evaluation("definitely_full_row", True),
+            _b1_transition_evaluation("not_applicable_no_move", False),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            context = _FakeCaptureContext([initial, candidate, candidate])
+            with mock.patch.object(
+                _MODULE, "evaluate_feedback_candidate", side_effect=b1_results
+            ), mock.patch.object(
+                _MODULE,
+                "_terminal_confirmed_overlap_pair_required",
+                return_value=True,
+            ) as reconcile:
+                result = StarBackpackCaptureProbe().run(
+                    context,
+                    SimpleNamespace(
+                        custom_action_param=_continuous_capture_params(directory)
+                    ),
+                )
+            _, session = self._session(directory)
+
+        self.assertTrue(getattr(result, "success", False))
+        self.assertEqual(len(session["adjacent_relations"]), 1)
+        reconcile.assert_not_called()
+
+    def test_no_move_before_progress_fails_without_an_extra_swipe(self):
+        initial = _complex_scene(height=760, width=240, seed=1431)
+        with tempfile.TemporaryDirectory() as directory:
+            context = _FakeCaptureContext([initial, initial])
+            result = StarBackpackCaptureProbe().run(
+                context,
+                SimpleNamespace(
+                    custom_action_param=_continuous_capture_params(directory)
+                ),
+            )
+            _, session = self._session(directory)
+
+        self.assertFalse(getattr(result, "success", True))
+        self.assertEqual(session["stop_reason"], "no_move_before_progress")
+        self.assertEqual(session["failed_transition"], 1)
+        self.assertEqual(session["retained_image_count"], 1)
+        self.assertEqual(len(context.tasker.controller.swipes), 1)
+
+    def test_unreliable_transition_stops_as_a_failure(self):
+        initial = _complex_scene(height=760, width=240, seed=1441)
+        candidate = _shift_up(initial, 620, seed=1442)
+        with tempfile.TemporaryDirectory() as directory:
+            context = _FakeCaptureContext([initial, candidate])
+            with mock.patch.object(
+                _MODULE,
+                "evaluate_feedback_candidate",
+                return_value=_b1_transition_evaluation(
+                    "not_applicable_unreliable_motion", False
+                ),
+            ):
+                result = StarBackpackCaptureProbe().run(
+                    context,
+                    SimpleNamespace(
+                        custom_action_param=_continuous_capture_params(directory)
+                    ),
+                )
+            run_dir, session = self._session(directory)
+            failed_candidate_exists = (run_dir / "failed-candidate-01.png").is_file()
+
+        self.assertFalse(getattr(result, "success", True))
+        self.assertEqual(session["stop_reason"], "unreliable_transition")
+        self.assertEqual(session["failed_transition"], 1)
+        self.assertEqual(session["adjacent_relations"], [])
+        self.assertNotIn("failed-candidate-01.png", session["retained_images"])
+        self.assertTrue(failed_candidate_exists)
+        self.assertEqual(len(context.tasker.controller.swipes), 1)
+
+    def test_rejected_transition_stops_as_a_failure(self):
+        initial = _complex_scene(height=760, width=240, seed=1451)
+        candidate = _shift_up(initial, 620, seed=1452)
+        with tempfile.TemporaryDirectory() as directory:
+            context = _FakeCaptureContext([initial, candidate])
+            with mock.patch.object(
+                _MODULE,
+                "evaluate_feedback_candidate",
+                return_value=_b1_transition_evaluation("definitely_full_row", False),
+            ):
+                result = StarBackpackCaptureProbe().run(
+                    context,
+                    SimpleNamespace(
+                        custom_action_param=_continuous_capture_params(directory)
+                    ),
+                )
+            run_dir, session = self._session(directory)
+            failed_candidate_exists = (run_dir / "failed-candidate-01.png").is_file()
+
+        self.assertFalse(getattr(result, "success", True))
+        self.assertEqual(session["stop_reason"], "rejected_transition")
+        self.assertEqual(session["failed_transition"], 1)
+        self.assertEqual(session["adjacent_relations"], [])
+        self.assertNotIn("failed-candidate-01.png", session["retained_images"])
+        self.assertTrue(failed_candidate_exists)
+        self.assertEqual(len(context.tasker.controller.swipes), 1)
+
+    def test_transition_limit_is_a_hard_failure_safety_valve(self):
+        initial = _complex_scene(height=760, width=240, seed=1461)
+        first = _shift_up(initial, 620, seed=1462)
+        second = _shift_up(first, 620, seed=1463)
+        with tempfile.TemporaryDirectory() as directory:
+            context = _FakeCaptureContext([initial, first, second])
+            with mock.patch.object(
+                _MODULE,
+                "evaluate_feedback_candidate",
+                side_effect=[
+                    _b1_transition_evaluation("definitely_no_full_row", True),
+                    _b1_transition_evaluation("ambiguous", True),
+                ],
+            ):
+                result = StarBackpackCaptureProbe().run(
+                    context,
+                    SimpleNamespace(
+                        custom_action_param=_continuous_capture_params(
+                            directory, max_transitions=2
+                        )
+                    ),
+                )
+            _, session = self._session(directory)
+
+        self.assertFalse(getattr(result, "success", True))
+        self.assertEqual(session["stop_reason"], "transition_limit_reached")
+        self.assertEqual(session["failed_transition"], 2)
+        self.assertEqual(session["retained_image_count"], 3)
+        self.assertEqual(len(context.tasker.controller.swipes), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent/tests/test_star_capture_transport.py
+++ b/agent/tests/test_star_capture_transport.py
@@ -1,0 +1,112 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+AGENT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(AGENT_ROOT))
+
+from custom.action import star_capture_transport as transport  # noqa: E402
+from custom.action.inventory_reporting import (  # noqa: E402
+    AUTO_UPLOAD_MODE,
+    UploadSettings,
+)
+
+
+PNG = b"\x89PNG\r\n\x1a\nminimal"
+
+
+def session():
+    return {
+        "success": True,
+        "stop_reason": "bottom_no_move",
+        "retained_images": ["capture-00.png", "capture-01.png"],
+        "adjacent_relations": [
+            {
+                "previous_image": "capture-00.png",
+                "current_image": "capture-01.png",
+                "relation": "overlap",
+            }
+        ],
+    }
+
+
+class _Response:
+    status = 200
+
+    def getcode(self):
+        return self.status
+
+    def read(self):
+        return b'{"status_code":200,"data":{"capture_id":"ignored"}}'
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+class StarCaptureTransportTests(unittest.TestCase):
+    def test_full_batch_maps_local_section_names_to_unique_wire_names(self):
+        with tempfile.TemporaryDirectory() as directory:
+            run_dir = Path(directory)
+            batch = {
+                "schemaVersion": 1, "captureId": "capture-full", "source": "maayuan", "gameVersion": "如鸢",
+                "sections": {
+                    "main": {"images": [{"sourceImageId": "capture-full:main:000", "sourceOrder": 1, "fileName": "main/capture-00.png"}, {"sourceImageId": "capture-full:main:001", "sourceOrder": 2, "fileName": "main/capture-01.png"}], "adjacentRelations": [{"previousSourceImageId": "capture-full:main:000", "currentSourceImageId": "capture-full:main:001", "relation": "overlap"}], "complete": True, "stopReason": "bottom_no_move"},
+                    "support": {"images": [{"sourceImageId": "capture-full:support:000", "sourceOrder": 3, "fileName": "support/capture-00.png"}], "adjacentRelations": [], "complete": True, "stopReason": "bottom_no_move"},
+                    "experience": {"images": [{"sourceImageId": "capture-full:experience:000", "sourceOrder": 4, "fileName": "experience/capture-00.png"}], "adjacentRelations": [], "complete": True, "stopReason": "single_capture"},
+                },
+            }
+            for section in ("main", "support", "experience"):
+                path = run_dir / section / "capture-00.png"
+                path.parent.mkdir()
+                path.write_bytes(PNG)
+            (run_dir / "main" / "capture-01.png").write_bytes(PNG)
+            manifest, wire_images = transport.build_full_capture_manifest(run_dir, batch)
+            body, _boundary = transport._multipart_body(manifest, wire_images)
+        self.assertEqual(list(manifest["sections"]), ["main", "support", "experience"])
+        self.assertEqual([image["source_order"] for section in manifest["sections"].values() for image in section["images"]], [1, 2, 3, 4])
+        self.assertEqual([name for name, _path in wire_images], ["main-000.png", "main-001.png", "support-000.png", "experience-000.png"])
+        self.assertIn(b'filename="support-000.png"', body)
+        self.assertNotIn(b'filename="capture-00.png"', body)
+
+    def test_manifest_uses_stable_capture_id_one_based_order_and_preserved_overlap(self):
+        with tempfile.TemporaryDirectory() as directory:
+            run_dir = Path(directory)
+            for name in session()["retained_images"]:
+                (run_dir / name).write_bytes(PNG)
+            first, paths = transport.build_main_capture_manifest(run_dir, session(), "如鸢")
+            second, _ = transport.build_main_capture_manifest(run_dir, session(), "如鸢")
+        self.assertEqual(first["capture_id"], second["capture_id"])
+        self.assertEqual([image["source_order"] for image in first["images"]], [1, 2])
+        self.assertTrue(first["images"][0]["source_image_id"].endswith(":000"))
+        self.assertTrue(first["images"][1]["source_image_id"].endswith(":001"))
+        self.assertEqual(len(paths), 2)
+        self.assertEqual(first["adjacent_relations"][0]["relation"], "overlap")
+
+    def test_multipart_upload_reuses_token_and_sends_manifest_and_each_png(self):
+        settings = UploadSettings(AUTO_UPLOAD_MODE, "secret-token", "https://hub.example")
+        with tempfile.TemporaryDirectory() as directory:
+            run_dir = Path(directory)
+            for name in session()["retained_images"]:
+                (run_dir / name).write_bytes(PNG)
+            manifest, paths = transport.build_main_capture_manifest(run_dir, session(), "如鸢")
+            with patch.object(transport.urllib_request, "urlopen", return_value=_Response()) as urlopen:
+                result = transport.upload_main_capture_manifest(manifest, paths, settings)
+        self.assertTrue(result.success)
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.full_url, "https://hub.example/open-api/star/captures")
+        self.assertEqual(request.get_header("Authorization"), "Bearer secret-token")
+        body = request.data
+        self.assertIn(b'name="manifest"', body)
+        self.assertEqual(body.count(b'name="files"'), 2)
+        self.assertIn(json.dumps(manifest, ensure_ascii=False, separators=(",", ":")).encode("utf-8"), body)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/assets/interface.json
+++ b/assets/interface.json
@@ -832,6 +832,34 @@
         }
       ]
     },
+    "同步星石至YuanHub": {
+      "type": "switch",
+      "default_case": "No",
+      "description": "将星石背包采集结果同步至 YuanHub，供 YuanStar 后续导入与识别使用。启用后需填写对应子账号的 YuanHub 连接码。",
+      "cases": [
+        {
+          "name": "No",
+          "pipeline_override": {
+            "在线上传认证": {
+              "attach": {
+                "mode": "仅保存到本地"
+              }
+            }
+          }
+        },
+        {
+          "name": "Yes",
+          "option": ["YuanHub连接码"],
+          "pipeline_override": {
+            "在线上传认证": {
+              "attach": {
+                "mode": "自动上报"
+              }
+            }
+          }
+        }
+      ]
+    },
     "保存到指定文件": {
       "type": "switch",
       "default_case": "No",
@@ -9332,6 +9360,16 @@
           "pipeline_override": {
             "百宝箱启动": {
               "next": ["背包识别-start"]
+            }
+          }
+        },
+        {
+          "name": "星石背包自动采集",
+          "description": "请先进入「星石背包 → 主星 → 顶部」。自动采集主星、辅星与经验星曜并组装完整批次；可选同步至 YuanHub。同步后 YuanStar 只载入截图，不会自动开始识别。",
+          "option": ["同步星石至YuanHub"],
+          "pipeline_override": {
+            "百宝箱启动": {
+              "next": ["星石背包-正式三段采集"]
             }
           }
         }

--- a/assets/resource/base/pipeline/pandorabox/analytics.json
+++ b/assets/resource/base/pipeline/pandorabox/analytics.json
@@ -3,8 +3,7 @@
     "attach": {
       "token": "",
       "inventory_report_filename": "",
-      "mode": "仅保存到本地",
-      "base_url": "http://172.29.133.116:8080"
+      "mode": "仅保存到本地"
     }
   },
   "背包识别-start": {

--- a/assets/resource/base/pipeline/star_backpack_capture_orchestration.json
+++ b/assets/resource/base/pipeline/star_backpack_capture_orchestration.json
@@ -1,0 +1,69 @@
+{
+  "星石背包-正式三段采集": {
+    "action": {
+      "type": "Custom",
+      "param": {
+        "custom_action": "StarBackpackCaptureOrchestration",
+        "custom_action_param": {
+          "mode": "continuous_capture",
+          "game_version": "如鸢",
+          "debug_dir": "debug/star-backpack-capture",
+          "support_tab_task": "星石背包-点击辅星",
+          "experience_tab_task": "星石背包-点击经验星曜",
+          "tab_settle_ms": 2500,
+          "compare_roi": [40, 280, 640, 760],
+          "swipe": {
+            "start": [360, 930],
+            "end": [360, 540],
+            "duration_ms": 700
+          },
+          "settle_ms": 2500,
+          "max_transitions": 20,
+          "feedback": {
+            "max_micro_attempts": 2,
+            "local_search_radius_px": 20,
+            "diagnostic_safe_shift_px": [300, 600],
+            "diagnostic_expected_shift_px": [250, 700],
+            "diagnostic_physical_shift_px": [30, 700],
+            "diagnostic_target_shift_px": [610, 630],
+            "diagnostic_normal_safe_shift_px": [560, 650],
+            "diagnostic_row_pitch_px": 166.5,
+            "diagnostic_micro_trigger_shift_px": 300,
+            "diagnostic_min_confidence": 0.2,
+            "diagnostic_min_local_overlap_score": 0.6,
+            "diagnostic_no_move_similarity": 0.97,
+            "diagnostic_no_move_shift_px": 20
+          }
+        }
+      }
+    },
+    "timeout": 180000,
+    "on_error": ["stop"]
+  },
+  "星石背包-点击辅星": {
+    "recognition": {
+      "type": "DirectHit",
+      "param": {
+        "roi": [320, 215, 80, 40]
+      }
+    },
+    "action": {
+      "type": "Click",
+      "param": {}
+    },
+    "on_error": ["stop"]
+  },
+  "星石背包-点击经验星曜": {
+    "recognition": {
+      "type": "DirectHit",
+      "param": {
+        "roi": [500, 215, 120, 40]
+      }
+    },
+    "action": {
+      "type": "Click",
+      "param": {}
+    },
+    "on_error": ["stop"]
+  }
+}

--- a/tools/sync_yuanstar_probe_runtime.ps1
+++ b/tools/sync_yuanstar_probe_runtime.ps1
@@ -1,0 +1,105 @@
+﻿[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$RuntimePath
+)
+
+$ErrorActionPreference = 'Stop'
+$sourceRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$runtimeRoot = (Resolve-Path -LiteralPath $RuntimePath).Path
+$backupTag = Get-Date -Format 'yyyyMMdd-HHmmss'
+
+function Backup-TargetFile {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if (Test-Path -LiteralPath $Path) {
+        Copy-Item -LiteralPath $Path -Destination "$Path.yuanstar-probe-backup-$backupTag" -Force
+    }
+}
+
+function Copy-ProbeFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$SourceRelativePath,
+        [Parameter(Mandatory = $true)][string]$RuntimeRelativePath
+    )
+    $source = Join-Path $sourceRoot $SourceRelativePath
+    $target = Join-Path $runtimeRoot $RuntimeRelativePath
+    if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
+        throw "开发文件不存在: $source"
+    }
+    $targetDirectory = Split-Path -Parent $target
+    if (-not (Test-Path -LiteralPath $targetDirectory -PathType Container)) {
+        throw "runtime 目录不存在: $targetDirectory"
+    }
+    Backup-TargetFile -Path $target
+    Copy-Item -LiteralPath $source -Destination $target -Force
+    Write-Host "已同步: $SourceRelativePath -> $RuntimeRelativePath"
+}
+
+# 只同步正式星石背包采集与完整批次上传所需文件；不触碰 config、日志、MaaYuan.exe、MFAAvalonia 或 Python runtime。
+Copy-ProbeFile -SourceRelativePath 'agent/custom/action/star_backpack_capture_probe.py' -RuntimeRelativePath 'agent/custom/action/star_backpack_capture_probe.py'
+Copy-ProbeFile -SourceRelativePath 'agent/custom/action/star_backpack_capture_orchestration.py' -RuntimeRelativePath 'agent/custom/action/star_backpack_capture_orchestration.py'
+Copy-ProbeFile -SourceRelativePath 'agent/custom/action/star_capture_transport.py' -RuntimeRelativePath 'agent/custom/action/star_capture_transport.py'
+Copy-ProbeFile -SourceRelativePath 'agent/custom/action/__init__.py' -RuntimeRelativePath 'agent/custom/action/__init__.py'
+Copy-ProbeFile -SourceRelativePath 'assets/resource/base/pipeline/star_backpack_capture_orchestration.json' -RuntimeRelativePath 'resource/base/pipeline/star_backpack_capture_orchestration.json'
+
+$sourceInterfacePath = Join-Path $sourceRoot 'assets/interface.json'
+$runtimeInterfacePath = Join-Path $runtimeRoot 'interface.json'
+if (-not (Test-Path -LiteralPath $runtimeInterfacePath -PathType Leaf)) {
+    throw "runtime interface.json 不存在: $runtimeInterfacePath"
+}
+
+$sourceInterface = Get-Content -LiteralPath $sourceInterfacePath -Encoding UTF8 -Raw | ConvertFrom-Json
+$runtimeInterface = Get-Content -LiteralPath $runtimeInterfacePath -Encoding UTF8 -Raw | ConvertFrom-Json
+if ($null -eq $sourceInterface.task -or $null -eq $runtimeInterface.task) {
+    throw 'interface schema 缺少 task，拒绝覆盖 runtime interface.json'
+}
+
+$debugTaskNames = @(
+    '开发调试｜星石背包截图探针',
+    '开发调试｜星石背包单次滑动探针',
+    '开发调试｜星石背包反馈滑动探针',
+    '开发调试｜星石背包连续采集',
+    '开发调试｜星石背包正式三段采集'
+)
+
+$sourceToolboxMode = $sourceInterface.option.PSObject.Properties['百宝箱-模式'].Value
+$runtimeToolboxMode = $runtimeInterface.option.PSObject.Properties['百宝箱-模式'].Value
+if ($null -eq $sourceToolboxMode -or $null -eq $runtimeToolboxMode) {
+    throw 'interface schema 缺少 百宝箱-模式，拒绝覆盖 runtime interface.json'
+}
+$sourceStarCase = @($sourceToolboxMode.cases | Where-Object { $_.name -eq '星石背包自动采集' })
+if ($sourceStarCase.Count -ne 1) {
+    throw '开发 interface 中未找到唯一的 星石背包自动采集 case'
+}
+
+# 只移除历史开发 task，并在既有百宝箱模式里替换正式星石 case。
+$runtimeInterface.task = @($runtimeInterface.task | Where-Object { $debugTaskNames -notcontains [string]$_.name })
+$patchedCases = New-Object System.Collections.Generic.List[object]
+$inserted = $false
+foreach ($case in @($runtimeToolboxMode.cases)) {
+    if ($case.name -eq '星石背包自动采集') {
+        continue
+    }
+    $patchedCases.Add($case)
+    if ($case.name -eq '自动识别背包') {
+        $patchedCases.Add($sourceStarCase[0])
+        $inserted = $true
+    }
+}
+if (-not $inserted) {
+    $patchedCases.Add($sourceStarCase[0])
+}
+$runtimeToolboxMode.cases = $patchedCases.ToArray()
+
+$sourceSyncOption = $sourceInterface.option.PSObject.Properties['同步星石至YuanHub'].Value
+if ($null -eq $sourceSyncOption) {
+    throw '开发 interface 中缺少 同步星石至YuanHub option'
+}
+[void]$runtimeInterface.option.PSObject.Properties.Remove('同步星石至YuanHub')
+$runtimeInterface.option | Add-Member -NotePropertyName '同步星石至YuanHub' -NotePropertyValue $sourceSyncOption
+
+Backup-TargetFile -Path $runtimeInterfacePath
+$runtimeInterface | ConvertTo-Json -Depth 100 | Set-Content -LiteralPath $runtimeInterfacePath -Encoding UTF8
+Write-Host "已安全 patch runtime interface.json（百宝箱正式 case 与同步 option）"
+Write-Host "完成。每个改写目标已有同目录 .yuanstar-probe-backup-$backupTag 备份。"


### PR DESCRIPTION
## 本次修改

在 MaaYuan 现有的「👆 百宝箱」中新增「星石背包自动采集」模式，用于自动完成星石背包三段截图采集，并可选择同步至 YuanHub。

该功能不会作为独立顶层任务出现，而是与「自动识别背包」「采集密探信息」等现有百宝箱功能保持同一入口结构。

## 采集流程

使用时先进入：

`星石背包 → 主星 → 顶部`

之后 MaaYuan 会依次执行：

1. 连续采集主星；
2. 自动点击 Tab 切换到辅星；
3. 连续采集辅星；
4. 自动点击 Tab 切换到经验星曜；
5. 经验星曜仅截取一张；
6. 将三段截图组装为完整 `CaptureBatchV1`；
7. 保留图片顺序与 overlap relations；
8. 如启用「同步星石至YuanHub」，则将完整批次上传至 YuanHub。

上传完成后只负责将截图送入 YuanStar，不会自动触发 OCR，识别仍由用户手动开始。

## 本次清理

本 PR 只保留正式生产链路需要的内容，开发过程中使用的调试入口和临时脚手架均未纳入。

已排除：

- 5 个顶层「开发调试｜星石……」任务；
- 4 份 debug / probe-only pipeline；
- main-only transport smoke；
- `prompt/archive`；
- 本地调试配置和临时诊断文件。

`star_backpack_capture_probe.py` 虽然文件名仍带 `probe`，但正式 orchestration 会直接复用其中的连续采集、motion 和 overlap primitive，因此作为生产依赖保留。

## 验证

- capture probe tests：72/72 PASS
- orchestration tests：3/3 PASS
- transport tests：3/3 PASS
- runtime sync：PASS
- `import custom`：PASS
- 已通过真实 13 图流程完成 MaaYuan → Backend → YuanHub → YuanStar E2E 验证

## 相关 PR

- Backend：MrSnake0208/BackEndV3-Share#5
  - 提供完整星石截图批次的上传、读取与 consume API，以及 `star:capture:write` 权限。
- YuanHub：MrSnake0208/YuanHub#6
  - 负责接收 `CaptureBatchV1`、恢复三类截图与 overlap relations，并导入 YuanStar embed。

## 补充修复

- 移除了 `pandorabox/analytics.json` 中「在线上传认证」节点遗留的硬编码局域网 `base_url`，避免本地地址覆盖统一的 `DEFAULT_BASE_URL` 并导致其他环境请求错误；
- 保留现有 fallback 机制：未显式配置 `base_url` 时使用 `inventory_reporting.py` 中的默认服务地址；
- 未写入任何本地 IP、token 或连接码。

## 补充验证

- 已完成真实 MaaYuan GUI E2E：从「百宝箱 → 星石背包自动采集」执行完整三段采集并上传，最终日志返回 `transport=HTTP 200`；
- full-batch 上传已在真实 16 张截图批次下验证成功；
- 本轮仅修复遗留 endpoint 覆盖问题，不改变星石采集与上传协议。